### PR TITLE
hotfix/update-credit

### DIFF
--- a/app/javascript/packs/order_screen.js
+++ b/app/javascript/packs/order_screen.js
@@ -143,7 +143,7 @@ document.addEventListener('turbolinks:load', () => {
               this.setUser(null);
             } else {
               // re-set user to update credit
-              this.setUser(response.body.user)
+              this.setUser(response.body.user);
             }
           }, this.handleXHRError );
         },
@@ -182,7 +182,7 @@ document.addEventListener('turbolinks:load', () => {
               this.setUser(null);
             } else {
               // re-set user to update credit
-              this.setUser(response.body.user)
+              this.setUser(response.body.user);
             }
             this.$refs.creditMutationModal.hide();
 


### PR DESCRIPTION
Fixes #189 
Deze PR zorgt er voor dat het saldo van een gebruiker ook wordt geupdate als je de gebruiker onthoudt. Dit doen we door de gebruiker wel opnieuw in te stellen maar wel weer op de huidige gebruiker.