### PR TITLE
Updated loofah dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
@@ -502,4 +502,4 @@ DEPENDENCIES
   webpacker (~> 3.5)
 
 BUNDLED WITH
-   1.16.2
+   1.17.1


### PR DESCRIPTION
Versie 2.2.2 heeft een XSS vulnerability en zorgt ervoor dat de pipeline failt, dus ik heb loofah geüpdatet naar versie 2.2.3.