### PR TITLE
Ignore CVE-2015-9284 in audit

### DIFF
--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -15,7 +15,7 @@ if [ "${TYPE}" = "lint" ] || [ "${TYPE}" = "" ]; then
 
   echo "--- :ruby: Bundle audit"
   gem install bundler-audit
-  bundle-audit update && bundle-audit check
+  bundle-audit update && bundle-audit check --ignore CVE-2015-9284
   RAILS_ENV=test bundle exec rails db:create db:environment:set db:schema:load
   # Don't check DB consistency until solved: https://github.com/trptcolin/consistency_fail/issues/42
   # bundle exec consistency_fail


### PR DESCRIPTION
Currently the CI is failing due to a CVE in omniauth. Since this vulnerability has no released mitigation we need to do this ourselfs. However, since we only have one oauth provider in use at the moment we do not need to fix this CVE, we can simply ignore it. 

More information in the PR about the issue: https://github.com/omniauth/omniauth/pull/809