### PR TITLE
Mutations layout

### DIFF
--- a/app/views/credit_mutations/index.html.slim
+++ b/app/views/credit_mutations/index.html.slim
@@ -42,4 +42,4 @@
                 td.text-nowrap
                   = number_to_currency(mutation.amount, unit: '€')
                 td.text-nowrap
-                  = l(mutation.created_at, format: "%d-%m-%y %H:%M")
+                  = l(mutation.created_at, format: :with_year)

--- a/app/views/credit_mutations/index.html.slim
+++ b/app/views/credit_mutations/index.html.slim
@@ -42,4 +42,4 @@
                 td.text-nowrap
                   = number_to_currency(mutation.amount, unit: '€')
                 td.text-nowrap
-                  = l(mutation.created_at, format: "%d-%m-%Y %H:%M")
+                  = l(mutation.created_at, format: "%d-%m-%y %H:%M")

--- a/app/views/credit_mutations/index.html.slim
+++ b/app/views/credit_mutations/index.html.slim
@@ -24,7 +24,7 @@
               th scope='col' = 'Beschrijving'
               th scope='col' = 'Gebruiker'
               th scope='col' = 'Activiteit'
-              th scope='col' = 'Geregistreerd door'
+              th.text-nowrap scope='col' = 'Geregistreerd door'
               th scope='col' = 'Bedrag'
               th scope='col' = 'Datum'
           tbody
@@ -39,7 +39,7 @@
                     = link_to mutation.activity&.title, mutation.activity
                 td
                   = link_to mutation.created_by.name, mutation.created_by
-                td
+                td.text-nowrap
                   = number_to_currency(mutation.amount, unit: '€')
-                td
-                  = l mutation.created_at
+                td.text-nowrap
+                  = l(mutation.created_at, format: "%d-%m-%Y %H:%M")

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -126,9 +126,9 @@
                         p.my-1
                           em = "#{@user.name} heeft nog niet ingelegd en er zijn nog geen correcties"
                   - else
-                    - @user.credit_mutations.each do |mutation|
+                    - @user.credit_mutations.order(created_at: :desc).each do |mutation|
                       tr
                         th scope='row' = mutation.id
-                        td = l mutation.created_at
+                        td = l(mutation.created_at, format: "%d-%m-%Y %H:%M")
                         td = mutation.description
                         td = number_to_currency(mutation.amount, unit: '€')

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -129,6 +129,6 @@
                     - @user.credit_mutations.order(created_at: :desc).each do |mutation|
                       tr
                         th scope='row' = mutation.id
-                        td = l(mutation.created_at, format: "%d-%m-%Y %H:%M")
+                        td = l(mutation.created_at, format: "%d-%m-%y %H:%M")
                         td = mutation.description
                         td = number_to_currency(mutation.amount, unit: '€')

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -129,6 +129,6 @@
                     - @user.credit_mutations.order(created_at: :desc).each do |mutation|
                       tr
                         th scope='row' = mutation.id
-                        td = l(mutation.created_at, format: "%d-%m-%y %H:%M")
+                        td = l(mutation.created_at, format: :with_year)
                         td = mutation.description
                         td = number_to_currency(mutation.amount, unit: '€')

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -2,6 +2,7 @@ nl:
   time:
     formats:
       default: '%d-%m %H:%M'
+      with_year: '%d-%m-%y %H:%M'
       long: '%d %B %Y %H:%M'
       date_only: '%d-%b-%y'
       time_only: '%H:%M'


### PR DESCRIPTION
This PR improves the layout of the mutations page and user mutations table.

Mutations page:
![image](https://user-images.githubusercontent.com/7385023/68850754-f450f080-06d4-11ea-8666-8d92e0ecceec.png)

![image](https://user-images.githubusercontent.com/7385023/68850617-a5a35680-06d4-11ea-8eca-e90e39c6e25e.png)

User mutations page:
![image](https://user-images.githubusercontent.com/7385023/68850780-029f0c80-06d5-11ea-9f81-c34b386c6142.png)

![image](https://user-images.githubusercontent.com/7385023/68850700-d2576e00-06d4-11ea-81f0-4b3255bc2944.png)
