### PR TITLE
Feature/manual lock

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -69,6 +69,21 @@ class ActivitiesController < ApplicationController
     @show_extras = false
   end
 
+  def lock
+    activity = Activity.find(params[:id])
+    authorize activity
+
+    activity.locked_by = current_user
+
+    if activity.save
+      flash[:success] = 'Successfully locked activity'
+    else
+      flash[:error] = activity.errors.full_messages.join(', ')
+    end
+
+    redirect_to activity
+  end
+
   private
 
   def users_hash

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,6 +3,7 @@ class Activity < ApplicationRecord
   has_many :credit_mutations, dependent: :destroy
   belongs_to :price_list
   belongs_to :created_by, class_name: 'User', inverse_of: :activities
+  belongs_to :locked_by, class_name: 'User', optional: true
 
   validates :title, :start_time, :end_time, :price_list, :created_by, presence: true
   validates_datetime :end_time, after: :start_time
@@ -76,7 +77,7 @@ class Activity < ApplicationRecord
   end
 
   def locked?
-    end_time && Time.zone.now > lock_date
+    locked_by || time_locked?
   end
 
   def lock_date
@@ -86,10 +87,14 @@ class Activity < ApplicationRecord
   private
 
   def activity_not_locked
-    errors.add(:base, 'Activity cannot be changed after lock date') if locked? && changed?
+    errors.add(:base, 'Activity cannot be changed when locked') if locked? && changed?
   end
 
   def destroyable?
     throw(:abort) if locked?
+  end
+
+  def time_locked?
+    end_time && Time.zone.now > lock_date
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -87,6 +87,7 @@ class Activity < ApplicationRecord
   private
 
   def activity_not_locked
+    return if locked_by_id_changed?(from: nil)
     errors.add(:base, 'Activity cannot be changed when locked') if locked? && changed?
   end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -88,6 +88,7 @@ class Activity < ApplicationRecord
 
   def activity_not_locked
     return if locked_by_id_changed?(from: nil)
+
     errors.add(:base, 'Activity cannot be changed when locked') if locked? && changed?
   end
 

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -3,6 +3,10 @@ class ActivityPolicy < ApplicationPolicy
     user&.treasurer? || user&.main_bartender?
   end
 
+  def lock?
+    user&.treasurer? && !record.locked?
+  end
+
   def activity_report?
     user&.treasurer?
   end

--- a/app/views/activities/show.html.slim
+++ b/app/views/activities/show.html.slim
@@ -222,3 +222,14 @@
                         tr
                           th scope='row' = product.name
                           td.text-right = "#{sum} x"
+    - unless @activity.locked?
+      .row
+        .col-sm-6.alert.alert-danger
+          .row
+            .col-md-8
+              = 'Het vergendelen van de activiteit zorgt er voor dat er geen wijzigingen meer op uitgevoerd kunnen worden. '
+              b
+                = 'Deze actie is niet ongedaan te maken!'
+            .col-md-4
+              = simple_form_for @activity, url: lock_activity_path, method: 'POST' do |f|
+                = f.button :submit, 'Activiteit vergrendelen', class: 'btn btn-danger'

--- a/app/views/activities/show.html.slim
+++ b/app/views/activities/show.html.slim
@@ -228,14 +228,14 @@
                         tr
                           th scope='row' = product.name
                           td.text-right = "#{sum} x"
-    - unless @activity.locked?
-      .row
-        .col-sm-6.alert.alert-danger
-          .row
-            .col-md-8
-              = 'Het vergendelen van de activiteit zorgt er voor dat er geen wijzigingen meer op uitgevoerd kunnen worden. '
-              b
-                = 'Deze actie is niet ongedaan te maken!'
-            .col-md-4
-              = simple_form_for @activity, url: lock_activity_path, method: 'POST' do |f|
-                = f.button :submit, 'Activiteit vergrendelen', class: 'btn btn-danger'
+  - unless @activity.locked?
+    .row
+      .col-sm-6
+        .alert.alert-danger
+          div
+            = 'Het vergendelen van de activiteit zorgt er voor dat er geen wijzigingen meer op uitgevoerd kunnen worden. '
+            b
+              = 'Deze actie is niet ongedaan te maken!'
+          .mt-3
+            = simple_form_for @activity, url: lock_activity_path, method: 'POST' do |f|
+              = f.button :submit, 'Activiteit vergrendelen', class: 'btn btn-danger'

--- a/app/views/activities/show.html.slim
+++ b/app/views/activities/show.html.slim
@@ -34,8 +34,12 @@
         - if @activity.locked?
           .card-text
             div class='alert alert-danger'
-              = 'Deze activiteit is langer dan een maand geleden afgelopen. Er kunnen geen nieuwe '
+              = 'Deze activiteit is vergrendeld. Er kunnen geen nieuwe '
               = 'bestellingen worden geplaatst en geen saldocorrecties meer worden toegevoegd'
+          - if @activity.locked_by
+            .card-text
+              div class='alert alert-info'
+                = "Deze activiteit is vergrendeld door #{@activity.locked_by.name}"
         - else
           p.card-text = 'Je kan bestellingen plaatsen in het streepscherm.'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :activities, only: %i[index show create update] do
     member do
       get :order_screen
+      post :lock
     end
   end
 

--- a/db/migrate/20191203092019_add_activity_lock.rb
+++ b/db/migrate/20191203092019_add_activity_lock.rb
@@ -1,0 +1,6 @@
+class AddActivityLock < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :activities, :locked_by, references: :users, index: true
+    add_foreign_key :activities, :users, column: :locked_by_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,17 +69,6 @@ ActiveRecord::Schema.define(version: 2019_12_03_092019) do
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
-  create_table "payments", force: :cascade do |t|
-    t.string "mollie_id"
-    t.decimal "amount", precision: 8, scale: 2
-    t.integer "status", default: 0, null: false
-    t.bigint "user_id"
-    t.datetime "deleted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_payments_on_user_id"
-  end
-
   create_table "price_lists", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "deleted_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,6 +69,17 @@ ActiveRecord::Schema.define(version: 2019_12_03_092019) do
     t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
+  create_table "payments", force: :cascade do |t|
+    t.string "mollie_id"
+    t.decimal "amount", precision: 8, scale: 2
+    t.integer "status", default: 0, null: false
+    t.bigint "user_id"
+    t.datetime "deleted_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_payments_on_user_id"
+  end
+
   create_table "price_lists", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "deleted_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_26_165012) do
+ActiveRecord::Schema.define(version: 2019_12_03_092019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,7 +24,9 @@ ActiveRecord::Schema.define(version: 2019_09_26_165012) do
     t.datetime "updated_at", null: false
     t.bigint "price_list_id"
     t.bigint "created_by_id"
+    t.bigint "locked_by_id"
     t.index ["created_by_id"], name: "index_activities_on_created_by_id"
+    t.index ["locked_by_id"], name: "index_activities_on_locked_by_id"
     t.index ["price_list_id"], name: "index_activities_on_price_list_id"
   end
 
@@ -138,6 +140,7 @@ ActiveRecord::Schema.define(version: 2019_09_26_165012) do
   end
 
   add_foreign_key "activities", "users", column: "created_by_id"
+  add_foreign_key "activities", "users", column: "locked_by_id"
   add_foreign_key "credit_mutations", "users", column: "created_by_id"
   add_foreign_key "orders", "users", column: "created_by_id"
 end

--- a/spec/controllers/activities_controller/lock_spec.rb
+++ b/spec/controllers/activities_controller/lock_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe ActivitiesController, type: :controller do
+  describe 'POST lock' do
+    let(:activity) { FactoryBot.create(:activity) }
+    let(:request) do
+      post :lock, params: { id: activity.id }
+    end
+
+    it 'unauthenticated when without permission' do
+      sign_in FactoryBot.create(:user)
+      request
+
+      expect(request.status).to eq 403
+    end
+
+    it 'unauthenticated when as main-bartender' do
+      sign_in FactoryBot.create(:user, :main_bartender)
+      request
+
+      expect(request.status).to eq 403
+    end
+
+    context 'when as treasurer' do
+      let(:user) { FactoryBot.create(:user, :treasurer)}
+
+      it 'locks the activity' do
+        sign_in user
+        request
+        activity.reload
+
+        expect(request.status).to eq 302
+        expect(activity.locked_by).to eq user
+      end
+
+      it 'unauthenticated when already locked' do
+        sign_in user
+        activity.locked_by = FactoryBot.create(:user)
+        activity.save
+        request
+
+        expect(request.status).to eq 403
+      end
+    end
+  end
+end

--- a/spec/controllers/activities_controller/lock_spec.rb
+++ b/spec/controllers/activities_controller/lock_spec.rb
@@ -22,7 +22,7 @@ describe ActivitiesController, type: :controller do
     end
 
     context 'when as treasurer' do
-      let(:user) { FactoryBot.create(:user, :treasurer)}
+      let(:user) { FactoryBot.create(:user, :treasurer) }
 
       it 'locks the activity' do
         sign_in user

--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -10,5 +10,9 @@ FactoryBot.define do
       start_time { Faker::Time.between(80.days.ago, 75.days.ago).beginning_of_hour }
       end_time { 74.days.ago.beginning_of_hour }
     end
+
+    trait :manually_locked do
+      association :locked_by, factory: :user
+    end
   end
 end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Activity, type: :model do
     end
 
     context 'when locked manually' do
-      subject(:activity) { FactoryBot.build(:activity, :manually_locked)}
+      subject(:activity) { FactoryBot.build(:activity, :manually_locked) }
 
       it { expect(activity).not_to be_valid }
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe Activity, type: :model do
 
       it { expect(activity).not_to be_valid }
     end
+
+    context 'when locked manually' do
+      subject(:activity) { FactoryBot.build(:activity, :manually_locked)}
+
+      it { expect(activity).not_to be_valid }
+    end
   end
 
   describe 'cannot destroy an activity when locked' do
@@ -72,6 +78,12 @@ RSpec.describe Activity, type: :model do
 
     context 'when after two months' do
       subject(:activity) { FactoryBot.build(:activity, :locked) }
+
+      it { expect(activity.destroy).to eq false }
+    end
+
+    context 'when manually locked' do
+      subject(:activity) { FactoryBot.build(:activity, :manually_locked) }
 
       it { expect(activity.destroy).to eq false }
     end


### PR DESCRIPTION
Fixes #398 
This PR adds the possibility to early lock activities. This way the treasurer can make sure that no changes are made after entering the details into the bookkeeping.

![Screenshot_2019-12-03_11-14-42](https://user-images.githubusercontent.com/5302372/70041800-1647df80-15be-11ea-87f6-e685db8c1468.png)
![Screenshot_2019-12-03_11-14-29](https://user-images.githubusercontent.com/5302372/70041801-1647df80-15be-11ea-9003-a7a7f66b7c9a.png)
