### PR TITLE
Set max amount of money fields

### DIFF
--- a/app/models/credit_mutation.rb
+++ b/app/models/credit_mutation.rb
@@ -3,7 +3,8 @@ class CreditMutation < ApplicationRecord
   belongs_to :activity, optional: true
   belongs_to :created_by, class_name: 'User', inverse_of: :credit_mutations
 
-  validates :description, :user, :created_by, :amount, presence: true
+  validates :description, :user, :created_by, presence: true
+  validates :amount, presence: true, numericality: { less_than_or_equal_to: 1000 }
 
   validate :activity_not_locked
 

--- a/app/models/product_price.rb
+++ b/app/models/product_price.rb
@@ -2,7 +2,7 @@ class ProductPrice < ApplicationRecord
   belongs_to :product
   belongs_to :price_list
 
-  validates :price, presence: true
+  validates :price, presence: true, inclusion: { in: 0..100 }
   validates :product_id, uniqueness: { scope: %i[price_list_id deleted_at] }
 
   delegate :name, to: :product

--- a/app/views/credit_mutations/_modal.html.erb
+++ b/app/views/credit_mutations/_modal.html.erb
@@ -13,7 +13,7 @@
         </button>
       </div><%= simple_form_for @new_mutation, wrapper: :horizontal_form do |f| %>
         <div class="modal-body" id="mutations_modal">
-          <%= f.input :description, placeholder: 'Beschrijving', required: true %>
+          <%= f.input :description, placeholder: 'Beschrijving' %>
           <%= f.input :amount, as: :float %>
 
           <div class="form-group row">

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -9,7 +9,7 @@ SimpleForm.setup do |config|
     b.optional :maxlength
     b.optional :minlength
     b.optional :pattern
-    b.optional :min_max
+    b.use :min_max
     b.optional :readonly
 
     b.use :label, class: 'col-form-label' do
@@ -61,7 +61,7 @@ SimpleForm.setup do |config|
     b.optional :maxlength
     b.optional :minlength
     b.optional :pattern
-    b.optional :min_max
+    b.use :min_max
     b.optional :readonly
 
     b.use :label, class: 'col-md-3 col-form-label'
@@ -119,7 +119,7 @@ SimpleForm.setup do |config|
     b.optional :maxlength
     b.optional :minlength
     b.optional :pattern
-    b.optional :min_max
+    b.use :min_max
     b.optional :readonly
 
     b.use :label, class: 'sr-only'

--- a/spec/models/credit_mutation_spec.rb
+++ b/spec/models/credit_mutation_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CreditMutation, type: :model do
       it { expect(mutation).not_to be_valid }
     end
 
-    context 'when with too much amount' do
+    context 'when with too high amount' do
       subject(:mutation) { FactoryBot.build_stubbed(:credit_mutation, amount: 1001) }
 
       it { expect(mutation).not_to be_valid }

--- a/spec/models/credit_mutation_spec.rb
+++ b/spec/models/credit_mutation_spec.rb
@@ -30,6 +30,12 @@ RSpec.describe CreditMutation, type: :model do
       it { expect(mutation).not_to be_valid }
     end
 
+    context 'when with too much amount' do
+      subject(:mutation) { FactoryBot.build_stubbed(:credit_mutation, amount: 1001) }
+
+      it { expect(mutation).not_to be_valid }
+    end
+
     context 'when with a locked activity' do
       let(:activity) { FactoryBot.build(:activity, :locked) }
       let(:mutation) { FactoryBot.build(:credit_mutation, activity: activity) }

--- a/spec/models/product_price_spec.rb
+++ b/spec/models/product_price_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe ProductPrice, type: :model do
       it { expect(product_price).not_to be_valid }
     end
 
+    context 'when with too much price' do
+      subject(:product_price) { FactoryBot.build_stubbed(:product_price, price: 101) }
+
+      it { expect(product_price).not_to be_valid }
+    end
+
     context 'when without a list' do
       subject(:product_price) { FactoryBot.build_stubbed(:product_price, price_list: nil) }
 

--- a/spec/models/product_price_spec.rb
+++ b/spec/models/product_price_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ProductPrice, type: :model do
       it { expect(product_price).not_to be_valid }
     end
 
-    context 'when with too much price' do
+    context 'when with too high price' do
       subject(:product_price) { FactoryBot.build_stubbed(:product_price, price: 101) }
 
       it { expect(product_price).not_to be_valid }


### PR DESCRIPTION
Fixes #244 
Make the fields `CreditMutation.amount` and `ProductPrice.price` capped by a max to prevent database overflows