### PR TITLE
Translate success message, only allow treasurer to see locking alert

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -89,7 +89,7 @@ class ActivitiesController < ApplicationController
     activity.locked_by = current_user
 
     if activity.save
-      flash[:success] = 'Successfully locked activity'
+      flash[:success] = 'Activiteit is succesvol vergrendeld'
     else
       flash[:error] = activity.errors.full_messages.join(', ')
     end

--- a/app/views/activities/show.html.slim
+++ b/app/views/activities/show.html.slim
@@ -229,7 +229,7 @@
                         tr
                           th scope='row' = product.name
                           td.text-right = "#{sum} x"
-  - unless @activity.locked?
+  - if current_user.treasurer? && !@activity.locked?
     .row
       .col-sm-6
         .alert.alert-danger


### PR DESCRIPTION
This PR fixes two bugs with the activity locking:
- See #413 
- The success popup is not in Dutch like the rest of the system 