### PR TITLE
Add automerge workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -25,3 +25,5 @@ jobs:
           MERGE_LABELS: "automerge"
           UPDATE_LABELS: ""
           UPDATE_METHOD: "rebase"
+          MERGE_RETRIES: "12"
+          MERGE_RETRY_SLEEP: "40000"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,27 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@2c8e667a3386187418587517e5bfe33470d19b5b"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "automerge"
+          UPDATE_LABELS: ""
+          UPDATE_METHOD: "rebase"


### PR DESCRIPTION
This PR adds an automerge workflow. (https://github.com/pascalgn/automerge-action)

In short:
When a PR has the automerge label it will be automatically be merged as soon as the checks are green and the PR is approved. It will also automatically rebase the branch as new changes will be pushed to the destination, which makes it easier to merge a lot of PRs in sequence without having to wait on the CI