### PR TITLE
Fix negative credit class

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -64,8 +64,7 @@
       <% end %>
       <h2>
         <span class="mr-1"><%= 'Saldo:' %></span>
-        <span class="
-          <% @user.credit <= 0 ? 'text-danger' : '' %>">
+        <span class="<%= @user.credit <= 0 ? 'text-danger' : '' %>">
           <%= number_to_currency(@user.credit, unit: '€') %>
         </span>
       </h2>


### PR DESCRIPTION
We missed an `=` in the erb file, which made the credit text not red when it became negative.

Fixe #419 