### PR TITLE
Fix streepsysteem leger code

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -21,6 +21,6 @@ nl:
     wine: 8040
     food: 8050
     tobacco: 8060
-    credit_mutation: 1400
+    credit_mutation: 0610
     cash: 1000
     pin: 2060


### PR DESCRIPTION
The streepsysteem ledger code 1400 was an activa while it should be a passiva. A new passiva ledger has been created with the code 0610.