### PR TITLE
Show lock on Activity.index

### DIFF
--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -32,6 +32,9 @@
           <% @activities&.each do |activity| %>
             <tr>
               <td>
+                <% if activity.locked? %>
+                  <%= fa_icon 'lock' %>
+                <% end %>
                 <%= link_to activity.title, activity %>
               </td>
               <td>


### PR DESCRIPTION
When an activity is locked it is nice for the treasurer to see this on the Activity index page. This way he/she knows immediately which are still open. 

![Screenshot_2020-01-04_18-25-51](https://user-images.githubusercontent.com/5302372/71769295-8cbe6100-2f1f-11ea-8a93-a70e60a83b7d.png)
