### PR TITLE
Fix streepsysteem accounting number

### DIFF
--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -21,6 +21,6 @@ nl:
     wine: 8040
     food: 8050
     tobacco: 8060
-    credit_mutation: 0610
+    credit_mutation: '0610'
     cash: 1000
     pin: 2060


### PR DESCRIPTION
The accounting number was interpreted as an octal number and thus not displayed correctly (displayed as 392). This PR will fix that. 