### PR TITLE
Feature/show negative credit amount in insufficient credit mailer

### DIFF
--- a/app/views/user_credit_mailer/insufficient_credit_mail.html.erb
+++ b/app/views/user_credit_mailer/insufficient_credit_mail.html.erb
@@ -1,7 +1,7 @@
 <p style="margin: 0; font-size: 16px; line-height: 20px">
-  U heeft op het moment een negatief Flux saldo. U wordt verzocht dit aan te
-  vullen tot minstens 5 euro positief zoals beschreven in het Huishoudelijk
-  Regelement van onze stichting.
+  Uw Flux saldo bedraagt momenteel: <span style="color:#ff0000;"><%= number_to_currency(@user.credit, unit: '€') %></span>
+  U wordt verzocht dit aan te vullen tot minstens 5 euro positief zoals
+  beschreven in het Huishoudelijk Regelement van onze stichting.
 </p>
 
 <br />

--- a/app/views/user_credit_mailer/insufficient_credit_mail.html.erb
+++ b/app/views/user_credit_mailer/insufficient_credit_mail.html.erb
@@ -1,5 +1,6 @@
 <p style="margin: 0; font-size: 16px; line-height: 20px">
   Uw Flux saldo bedraagt momenteel: <span style="color:#ff0000;"><%= number_to_currency(@user.credit, unit: '€') %></span>
+  <br />
   U wordt verzocht dit aan te vullen tot minstens 5 euro positief zoals
   beschreven in het Huishoudelijk Regelement van onze stichting.
 </p>

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :user do
     name { Faker::Movies::StarWars.character }
 
+    sequence(:email) { |n| Faker::Internet.safe_email(name: "#{Faker::Internet.user_name}#{n}") }
+
     trait(:treasurer) do
       after :create do |user, _evaluator|
         user.roles = [FactoryBot.create(:role, role_type: :treasurer)]


### PR DESCRIPTION
This pull requests changes the insufficient credit mailer's content so that the regarding negative amount of credits is shown (and is red).

This PR resolves #278. 