### PR TITLE
Do not load sentry when on localhost

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,17 +17,18 @@
     <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/animate.css@3.5.2/animate.min.css" rel="stylesheet"/>
     <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport"/>
 
-    <script>
-      Sentry.init({
-        dsn: 'https://56243c9c41a549ba92e50b0a5b642e32@sentry.io/267713',
-        debug: true,
-        environment: '<%= Rails.env %>'
-      });
+    <% if Rails.application.config.x.sentry_dsn %>
+      <script>
+        Sentry.init({
+          dsn: '<%= Rails.application.config.x.sentry_dsn %>',
+          environment: '<%= Rails.env %>'
+        });
 
-      Sentry.configureScope(scope => {
-        scope.setUser({ id: <%= current_user&.id || 'null' %> });
-      });
-    </script>
+        Sentry.configureScope(scope => {
+          scope.setUser({ id: <%= current_user&.id || 'null' %> });
+        });
+      </script>
+    <% end %>
 
 
 


### PR DESCRIPTION
By accident the sentry implementation was to always log (also on localhost). This PR fixes that.

The previous sentry commit included the DSN, which could be considered an secret so we should change that one after this PR is merged and deployed