### PR TITLE
Remove duplicates in manually_added_users_with_orders

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -3,6 +3,7 @@ class Activity < ApplicationRecord
 
   has_many :orders, dependent: :destroy
   has_many :credit_mutations, dependent: :destroy
+  has_many :ordering_users, through: :orders, source: :user
   belongs_to :price_list
   belongs_to :created_by, class_name: 'User', inverse_of: :activities
   belongs_to :locked_by, class_name: 'User', optional: true
@@ -28,7 +29,7 @@ class Activity < ApplicationRecord
   delegate :products, to: :price_list
 
   def manually_added_users_with_orders
-    orders.by_manually_added_user.map(&:user)
+    ordering_users.where('provider IS NULL').distinct
   end
 
   def credit_mutations_total

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -16,7 +16,6 @@ class Order < ApplicationRecord
   before_destroy -> { throw(:abort) }
 
   scope :orders_for, (->(user) { where(user: user) })
-  scope :by_manually_added_user, -> { joins(:user).where('users.provider IS NULL') }
 
   def order_total
     @sum ||= order_rows.sum('product_count * price_per_product')

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -346,11 +346,15 @@ RSpec.describe Activity, type: :model do
     let(:manually_added_user) { FactoryBot.create(:user) }
     let(:manually_added_user_order) { FactoryBot.create(:order, user: manually_added_user, activity: activity) }
 
+    # Make sure that a user only shows up once in the list, even if he/she has placed multiple orders
+    let(:second_manually_added_user_order) { FactoryBot.create(:order, user: manually_added_user, activity: activity) }
+
     let(:provider_added_user) { FactoryBot.create(:user, provider: 'some_provider') }
     let(:provider_added_user_order) { FactoryBot.create(:order, user: provider_added_user, activity: activity) }
 
     before do
       manually_added_user_order
+      second_manually_added_user_order
       provider_added_user_order
     end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -67,20 +67,4 @@ RSpec.describe Order, type: :model do
 
     it { expect(order.destroy).to eq false }
   end
-
-  describe '.by_manually_added_user' do
-    let(:manually_added_user) { FactoryBot.create(:user) }
-    let(:manually_added_user_order) { FactoryBot.create(:order, user: manually_added_user) }
-
-    let(:provider_added_user) { FactoryBot.create(:user, provider: 'some_provider') }
-    let(:provider_added_user_order) { FactoryBot.create(:order, user: provider_added_user) }
-
-    before do
-      manually_added_user_order
-      provider_added_user_order
-    end
-
-    it { expect(described_class.by_manually_added_user).to include manually_added_user_order }
-    it { expect(described_class.by_manually_added_user).not_to include provider_added_user_order }
-  end
 end


### PR DESCRIPTION
Duplicates were not removed so when a user placed multiple orders he would show up multiple times in the list. This is of course not the intended behaviour.