### PR TITLE
Add deleted_at index on product_prices table migration

### DIFF
--- a/db/migrate/20200324110203_change_product_price_constraint.rb
+++ b/db/migrate/20200324110203_change_product_price_constraint.rb
@@ -1,0 +1,7 @@
+class ChangeProductPriceConstraint < ActiveRecord::Migration[6.0]
+  def change
+    remove_index :product_prices, %i[product_id price_list_id]
+    add_index :product_prices, %i[product_id price_list_id deleted_at],
+              name: 'index_product_prices_on_product_id_and_price_list_id', unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_03_092019) do
+ActiveRecord::Schema.define(version: 2020_03_24_110203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
In this commit (https://github.com/csvalpha/sofia/commit/af2226a63faa93def08e3e3af8afa137a344e252) we forgot to add the migration. This causes an issue which was not reproducible on local but did happen on production. This PR fixes the issue by adding the migration.