### PR TITLE
Add a users totals table

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -102,3 +102,9 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,6 +43,15 @@ body {
   }
 }
 
+.users-table [aria-colindex="1"] {
+  /* ID column */
+  width: 100px;
+}
+.users-table [aria-colindex="3"] {
+  /* Saldo column */
+  width: 150px;
+}
+
 .b-table-details--header {
   background-color: $gray-200;
   text-transform: uppercase;

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,28 +3,28 @@ class UsersController < ApplicationController
 
   after_action :verify_authorized
 
-  def index
+  def index # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     @users = User.all.order(:name)
     authorize @users
 
     @users_credits = User.calculate_credits
     @users_with_credits = @users.as_json
-                              .each { |u| u['credit'] = @users_credits.fetch(u['id'], 0) }
+                                .each { |u| u['credit'] = @users_credits.fetch(u['id'], 0) }
 
     @users_json = @users_with_credits.to_json(only: %w[id name credit])
 
     @banana_users_total = @users_with_credits
-                               .filter { |u| u['provider'] == 'banana_oauth2' }
-                               .inject(0) { |sum, u| sum + u['credit'] }
+                          .filter { |u| u['provider'] == 'banana_oauth2' }
+                          .inject(0) { |sum, u| sum + u['credit'] }
 
     @users_totals = @users_with_credits
-                        .filter { |u| u['provider'] != 'banana_oauth2' and u['credit'] != 0 }
+                    .filter { |u| u['provider'] != 'banana_oauth2' && u['credit'] != 0 }
 
     @users_totals.unshift({
-        'id' => '',
-        'name' => 'Alpha gebruikers',
-        'credit' => @banana_users_total
-    })
+                            'id' => '',
+                            'name' => 'Alpha gebruikers',
+                            'credit' => @banana_users_total
+                          })
 
     @new_user = User.new
   end

--- a/app/javascript/components/user/userstable.vue
+++ b/app/javascript/components/user/userstable.vue
@@ -1,0 +1,72 @@
+<template lang="html">
+  <div class="col-sm-12">
+    <h3>{{this.title}}</h3>
+    <b-table :fields="fields" :items="users" responsive="" show-empty="" sort-by="name" striped="">
+      <template v-slot:cell(name)="data">
+        <a :href="`/users/${data.item.id}`">
+          {{data.value}}
+        </a></template>
+      <template v-slot:empty>
+        <p class="my-1 text-center">
+          <em>Er zijn geen gebruikers om weer te geven
+          </em>
+        </p>
+      </template>
+      <template v-slot:custom-foot>
+        <b-tr>
+          <b-th></b-th>
+          <b-th>Totaal</b-th>
+          <b-th>€ {{parseFloat(total).toFixed(2)}}</b-th>
+        </b-tr>
+      </template>
+    </b-table>
+  </div>
+</template>
+
+<script>
+  export default {
+    props: {
+      users: {
+        type: Array,
+        required: true
+      },
+      title: {
+        type: String,
+        required: true
+      }
+    },
+
+    data: function () {
+      return {
+        fields: [
+          {
+            key: 'id',
+            label: '#',
+            sortable: true,
+            isRowHeader: true
+          },
+          {
+            key: 'name',
+            label: 'Naam',
+            sortable: true
+          },
+          {
+            key: 'credit',
+            label: 'Saldo',
+            sortable: true,
+            tdClass: (value) => {
+              return value <= 0 ? 'text-danger' : '';
+            },
+            formatter: (value) => `€ ${parseFloat(value).toFixed(2)}`,
+          }
+        ]
+      };
+    },
+    computed: {
+      total: function() {
+        return this.users.map(user => user.credit)
+          .reduce((current, credit) => parseFloat(current) + parseFloat(credit));
+      }
+    }
+  };
+</script>

--- a/app/javascript/components/user/userstable.vue
+++ b/app/javascript/components/user/userstable.vue
@@ -1,26 +1,23 @@
 <template lang="html">
-  <div class="col-sm-12">
-    <h3>{{this.title}}</h3>
-    <b-table :fields="fields" :items="users" responsive="" show-empty="" sort-by="name" striped="">
-      <template v-slot:cell(name)="data">
-        <a :href="`/users/${data.item.id}`">
-          {{data.value}}
-        </a></template>
-      <template v-slot:empty>
-        <p class="my-1 text-center">
-          <em>Er zijn geen gebruikers om weer te geven
-          </em>
-        </p>
-      </template>
-      <template v-slot:custom-foot>
-        <b-tr>
-          <b-th></b-th>
-          <b-th>Totaal</b-th>
-          <b-th>€ {{parseFloat(total).toFixed(2)}}</b-th>
-        </b-tr>
-      </template>
-    </b-table>
-  </div>
+  <b-table class="users-table" :fields="fields" :items="users" responsive="" show-empty="" sort-by="name" striped="">
+    <template v-slot:cell(name)="data">
+      <a :href="`/users/${data.item.id}`">
+        {{data.value}}
+      </a></template>
+    <template v-slot:empty>
+      <p class="my-1 text-center">
+        <em>Er zijn geen gebruikers om weer te geven
+        </em>
+      </p>
+    </template>
+    <template v-slot:custom-foot>
+      <b-tr>
+        <b-th></b-th>
+        <b-th>Totaal</b-th>
+        <b-th :class="total < 0 ? 'text-danger' : ''">€ {{parseFloat(total).toFixed(2)}}</b-th>
+      </b-tr>
+    </template>
+  </b-table>
 </template>
 
 <script>
@@ -28,10 +25,6 @@
     props: {
       users: {
         type: Array,
-        required: true
-      },
-      title: {
-        type: String,
         required: true
       }
     },
@@ -55,7 +48,7 @@
             label: 'Saldo',
             sortable: true,
             tdClass: (value) => {
-              return value <= 0 ? 'text-danger' : '';
+              return value < 0 ? 'text-danger' : '';
             },
             formatter: (value) => `€ ${parseFloat(value).toFixed(2)}`,
           }

--- a/app/javascript/packs/users.js
+++ b/app/javascript/packs/users.js
@@ -2,6 +2,7 @@ import Vue from 'vue/dist/vue.esm';
 import TurbolinksAdapter from 'vue-turbolinks';
 import axios from 'axios';
 import BootstrapVue from 'bootstrap-vue';
+import UsersTable from '../components/user/userstable.vue';
 
 Vue.use(TurbolinksAdapter);
 Vue.use(BootstrapVue);
@@ -11,35 +12,16 @@ document.addEventListener('turbolinks:load', () => {
 
   var element = document.getElementById('users-index');
   if (element !== null) {
-    var users = JSON.parse(element.dataset.users);
+    var manual_users = JSON.parse(element.dataset.manualUsers);
+    var amber_users = JSON.parse(element.dataset.amberUsers);
     new Vue({
       el: element,
-      data: () => {
-        return {
-          users: users,
-          fields: [
-            {
-              key: 'id',
-              label: '#',
-              sortable: true,
-              isRowHeader: true
-            },
-            {
-              key: 'name',
-              label: 'Naam',
-              sortable: true
-            },
-            {
-              key: 'credit',
-              label: 'Saldo',
-              sortable: true,
-              tdClass: (value) => {
-                return value <= 0 ? 'text-danger' : '';
-              },
-              formatter: (value) => `€ ${parseFloat(value).toFixed(2)}`,
-            }
-          ]
-        };
+      data: () => ({
+        manual_users,
+        amber_users
+      }),
+      components: {
+        UsersTable
       },
     });
   }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   validates :uid, uniqueness: true, allow_blank: true
 
   scope :in_banana, (-> { where(provider: 'banana_oauth2') })
+  scope :manual, (-> { where(provider: nil) })
   scope :treasurer, (-> { joins(:roles).merge(Role.treasurer) })
 
   def credit

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,30 +4,29 @@
 <% end %>
 
 <div class="container footer-padding">
-  <div class="row pt-4">
-    <div class="col-sm-12 d-flex justify-content-between align-items-center">
-      <h1>Gebruikers</h1>
+  <h1 class="my-4">Gebruikers</h1>
+
+  <%= content_tag :div, id: 'users-index', data: {manual_users: @manual_users_json, amber_users: @amber_users_json} do %>
+    <div class="d-flex justify-content-between align-items-center">
+      <h3>Handmatig aangemaakte gebruikers</h3>
+      <button class="btn btn-sm btn-primary" data-target="#edit_user_modal" data-toggle="modal" role="button">
+        <%= fa_icon 'plus' %>
+        <span class="d-none d-md-inline ml-1">
+          Nieuwe gebruiker
+        </span>
+      </button>
+    </div>
+    <users-table :users="manual_users"></users-table>
+
+    <div class="d-flex justify-content-between align-items-center">
+      <h3>Amber gebruikers</h3>
       <span>
         <%= link_to refresh_user_list_users_path, class: 'btn btn-primary btn-sm mr-1' do %>
-        <%= fa_icon 'refresh' %>
+          <%= fa_icon 'refresh' %>
           <span class="d-none d-md-inline ml-1">Synchroniseer gebruikers</span>
         <% end %>
-
-        <button class="btn btn-sm btn-primary" data-target="#edit_user_modal" data-toggle="modal" role="button">
-          <%= fa_icon 'plus' %>
-          <span class="d-none d-md-inline ml-1">
-            Nieuwe gebruiker
-          </span>
-      </button>
       </span>
     </div>
-  </div>
-
-  <%= content_tag :div, id: 'users-index', class: 'row', data: {manual_users: @manual_users_json, amber_users: @amber_users_json} do %>
-    <users-table :title="'Handmatig aangemaakte gebruikers'" :users="manual_users">
-    </users-table>
-
-    <users-table :title="'Amber gebruikers'" :users="amber_users">
-    </users-table>
+    <users-table :users="amber_users"></users-table>
   <% end %>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -38,5 +38,37 @@
       </b-table>
     </div>
   <% end %>
+
   <hr/>
+
+  <h3>Totalen</h3>
+
+  <div class="table-responsive">
+    <table class="table table-striped">
+      <thead>
+      <tr>
+        <th>#</th>
+        <th>Naam</th>
+        <th>Saldo</th>
+      </tr>
+      </thead>
+      <tbody>
+        <% @users_totals.each do |user| %>
+          <tr>
+            <th><%= user['id'] %></th>
+            <td>
+              <a href="/users/<%= user['id'] %>">
+                <%= user['name'] %>
+              </a>
+            </td>
+            <td>
+              <span class="<%= user['credit'] <= 0 ? 'text-danger' : '' %>">
+                <%= number_to_currency(user['credit'], unit: '€') %>
+              </span>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,52 +23,11 @@
     </div>
   </div>
 
-  <%= content_tag :div, id: 'users-index', class: 'row', data: {users: @users_json} do %>
-    <div class="col-sm-12">
-      <b-table :fields="fields" :items="users" responsive="" show-empty="" sort-by="name" striped="">
-        <template v-slot:cell(name)="data">
-          <a :href="`/users/${data.item.id}`">
-            {{data.value}}
-          </a></template>
-        <template v-slot:empty>
-          <p class="my-1 text-center">
-            <em>Er zijn geen gebruikers om weer te geven
+  <%= content_tag :div, id: 'users-index', class: 'row', data: {manual_users: @manual_users_json, amber_users: @amber_users_json} do %>
+    <users-table :title="'Handmatig aangemaakte gebruikers'" :users="manual_users">
+    </users-table>
 
-            </em></p></template>
-      </b-table>
-    </div>
+    <users-table :title="'Amber gebruikers'" :users="amber_users">
+    </users-table>
   <% end %>
-
-  <hr/>
-
-  <h3>Totalen</h3>
-
-  <div class="table-responsive">
-    <table class="table table-striped">
-      <thead>
-      <tr>
-        <th>#</th>
-        <th>Naam</th>
-        <th>Saldo</th>
-      </tr>
-      </thead>
-      <tbody>
-        <% @users_totals.each do |user| %>
-          <tr>
-            <th><%= user['id'] %></th>
-            <td>
-              <a href="/users/<%= user['id'] %>">
-                <%= user['name'] %>
-              </a>
-            </td>
-            <td>
-              <span class="<%= user['credit'] <= 0 ? 'text-danger' : '' %>">
-                <%= number_to_currency(user['credit'], unit: '€') %>
-              </span>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
-  </div>
 </div>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,6 +31,24 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '.manual' do
+    context 'when manual created' do
+      subject(:user) { FactoryBot.create(:user, provider: nil) }
+
+      before { user }
+
+      it { expect(described_class.manual).to include user }
+    end
+
+    context 'when created via provider' do
+      subject(:user) { FactoryBot.create(:user, provider: 'another_provider') }
+
+      before { user }
+
+      it { expect(described_class.manual).not_to include user }
+    end
+  end
+
   describe '.treasurer' do
     context 'when treasurer' do
       subject(:user) { FactoryBot.create(:user) }


### PR DESCRIPTION
This PR will add a totals table at the bottom of the users page. This table will show a sum of all the credits of users synched from banana, and all the manually created users with a non-zero credit total. This will make it easy for the treasurer to see if the total credit in SOFIA is equal to the credit in the bookkeeping software. It will also make it easier to check if any manually created accounts still need to receive an invoice.

The Ruby code can probably be nicer, so feel free to improve it :sweat_smile:  

![image](https://user-images.githubusercontent.com/7385023/79442487-e3d0d900-7fd8-11ea-80fc-6cd534e799de.png)
