### PR TITLE
Hotfix/sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,9 +1,9 @@
 Raven.configure do |config|
-  # config.dsn = Rails.application.config.x.sentry_dsn
-  # config.environments = %w[production staging]
-  # config.current_environment = Rails.env
-  # config.async = lambda { |event|
-  #  SentryJob.perform_later(event)
-  # }
-  # config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  config.dsn = Rails.application.config.x.sentry_dsn
+  config.environments = %w[production staging]
+  config.current_environment = Rails.env
+  config.async = lambda { |event|
+    SentryJob.perform_later(event)
+  }
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 end


### PR DESCRIPTION
By accident sentry was disabled after the rails 6 upgrade. This PR fixes that

Fixes #464