### PR TITLE
Clarify lock date text

### DIFF
--- a/app/views/activities/show.html.erb
+++ b/app/views/activities/show.html.erb
@@ -31,7 +31,7 @@
           <td><%= l @activity.end_time, format: :long %></td>
         </tr>
         <tr>
-          <th scope="row">Vergrendelt op</th>
+          <th scope="row">Vergrendelt automatisch op</th>
           <td><%= l @activity.lock_date, format: :long %></td>
         </tr>
         <tr>


### PR DESCRIPTION
Op het moment staat er in de show pagina van de activiteiten 'vergrendeld op', maar als hij dan al eerder vergrendeld is is dat een beetje gek. Heb er nu dus van gemaakt 'Vergrendeld automatisch op', dat maakt het wat duidelijker.