### PR TITLE
Fix activity page

### DIFF
--- a/app/javascript/packs/activities.js
+++ b/app/javascript/packs/activities.js
@@ -8,7 +8,7 @@ Vue.use(VueResource);
 document.addEventListener('turbolinks:load', () => {
   Vue.http.headers.common['X-CSRF-TOKEN'] = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
 
-  var element = document.getElementById('edit_activity_modal');
+  var element = document.getElementById('new_activity_modal');
   if (element !== null) {
     var price_lists = JSON.parse(element.dataset.priceLists);
     new Vue({

--- a/app/views/activities/_modal.html.erb
+++ b/app/views/activities/_modal.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag :div, class: 'modal', id: 'edit_activity_modal', role: 'dialog', 'aria-labelledby' => 'edit_activity_modal_label', 'aria-hidden' => 'true', data: {price_lists: @price_lists_json} do %>
+<%= content_tag :div, class: 'modal', id: 'new_activity_modal', role: 'dialog', 'aria-labelledby' => 'new_activity_modal_label', 'aria-hidden' => 'true', data: {price_lists: @price_lists_json} do %>
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">

--- a/app/views/activities/index.html.erb
+++ b/app/views/activities/index.html.erb
@@ -9,7 +9,7 @@
       <h1>
         Activiteiten
       </h1>
-      <button class="btn btn-sm btn-primary" data-target="#edit_activity_modal" data-toggle="modal" role="button">
+      <button class="btn btn-sm btn-primary" data-target="#new_activity_modal" data-toggle="modal" role="button">
         <%= fa_icon 'plus' %>
         <span class="d-none d-md-inline ml-1">
           Nieuwe activiteit


### PR DESCRIPTION
The activity page was trying to load the priceList dataset, that it didn't had. This causes a error (without an issue on the page itself). This was caused by the fact that the selector of the model on the activity page was the same as the activities page.

https://sentry.io/organizations/csvalpha/issues/1887249022/?project=267713&query=is%3Aunresolved