### PR TITLE
Make readme consistent with Amber-API

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ $ EDITOR="code --wait" bundle exec rails credentials:edit
 In OAuth Banana (github.com/csvalpha/alpha-banana-api), execute the following command (in `rails console`):
 
 ```ruby
-Doorkeeper::Application.create(name: 'SOFIA - Streepsysteem der C.S.V. Alpha', redirect_uri: 'http://localhost:5000/users/auth/banana_oauth2/callback', scopes: 'public tomato')
+app = Doorkeeper::Application.create(name: 'SOFIA - Streepsysteem der C.S.V. Alpha', redirect_uri: 'http://localhost:5000/users/auth/banana_oauth2/callback', scopes: 'public tomato')
+app.uid
+app.plaintext_secret
 ```
 
-Next, copy the uid and secret to the `.env` in SOFIA (as `banana_client_id` and `banana_client_secret`).
+Next, copy the uid and plaintext secret to the `.env` in SOFIA (as `banana_client_id` and `banana_client_secret`).
 
 ### Configuring roles
 


### PR DESCRIPTION
We've applied hashing to the amber api so creating the app is a little bit different, so let's make the readme consistent