### PR TITLE
Increase number of price lists shown

### DIFF
--- a/app/controllers/price_lists_controller.rb
+++ b/app/controllers/price_lists_controller.rb
@@ -4,7 +4,7 @@ class PriceListsController < ApplicationController
   after_action :verify_authorized
 
   def index
-    recent_price_lists = PriceList.order(created_at: :desc).limit(5)
+    recent_price_lists = PriceList.order(created_at: :desc).limit(6)
     products = Product.all.order(:id).includes(:product_prices)
 
     authorize recent_price_lists


### PR DESCRIPTION
There are currently 6 price lists but the last one is not shown. 6 also still fits fine on a normal screen.