### PR TITLE
fix(problem-matchers): match correct path in ESLint matcher

### DIFF
--- a/.github/problem-matchers/eslint-stylish.json
+++ b/.github/problem-matchers/eslint-stylish.json
@@ -4,7 +4,7 @@
       "owner": "eslint-stylish",
       "pattern": [
         {
-          "regexp": "^/opt/app/([^\\s].*)$",
+          "regexp": "^/app/app/([^\\s].*)$",
           "file": 1
         },
         {


### PR DESCRIPTION
### Summary

Fixes the ESLint problem matcher, apparently the path is /app/app instead of /opt/app.
