### PR TITLE
Hotfix insufficient credit provider

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User < ApplicationRecord
   end
 
   def insufficient_credit
-    provider == 'banana_oauth2' and credit < -5
+    provider == 'amber_oauth2' and credit < -5
   end
 
   def treasurer?


### PR DESCRIPTION
#741 and #697 were not merged together properly, causing #741 to still refer to the old `banana_oauth2` provider instead of `amber_oauth2`. This hotfix fixes that.