### PR TITLE
Fix sumup on iPadOS

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -98,9 +98,8 @@ class ActivitiesController < ApplicationController # rubocop:disable Metrics/Cla
 
     @activity_json = @activity.to_json(only: %i[id title start_time end_time])
 
-    is_mobile = Browser.new(request.user_agent).mobile?
     @sumup_key = Rails.application.config.x.sumup_key
-    @sumup_enabled = (is_mobile && @sumup_key.present?) || false
+    @sumup_enabled = @sumup_key.present?
 
     # Set flags for application.html.slim
     @show_navigationbar = false

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -84,7 +84,7 @@ class ActivitiesController < ApplicationController # rubocop:disable Metrics/Cla
     @count_per_product = @activity.count_per_product
   end
 
-  def order_screen # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+  def order_screen # rubocop:disable Metrics/MethodLength
     authorize Activity
 
     @activity = Activity.includes([:price_list, { price_list: { product_price: :product } }])

--- a/app/javascript/packs/order_screen.js
+++ b/app/javascript/packs/order_screen.js
@@ -274,6 +274,11 @@ document.addEventListener('turbolinks:load', () => {
           let callback = element.dataset.sumupCallback;
           return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&total=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&callback=${callback}`;
         },
+
+        isMobile() {
+          return /Android|webOS|iPhone|iPad|iPod|Opera Mini/i.test(navigator.userAgent) || // Android / iOS
+            (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) // iPadOS
+        }
       },
 
       // Listen to escape button which are dispatched on the body content_tag

--- a/app/javascript/packs/order_screen.js
+++ b/app/javascript/packs/order_screen.js
@@ -277,7 +277,7 @@ document.addEventListener('turbolinks:load', () => {
 
         isMobile() {
           return /Android|webOS|iPhone|iPad|iPod|Opera Mini/i.test(navigator.userAgent) || // Android / iOS
-            (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) // iPadOS
+            (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1); // iPadOS
         }
       },
 

--- a/app/views/activities/order_screen.html.erb
+++ b/app/views/activities/order_screen.html.erb
@@ -182,7 +182,7 @@
         </div>
       </div>
       <div class="orders-confirmation">
-        <div class="btn-group btn-group-lg btn-block" role="group" v-if="payWithPin && <%= @sumup_enabled.to_s %>">
+        <div class="btn-group btn-group-lg btn-block" role="group" v-if="payWithPin && <%= @sumup_enabled.to_s %> && isMobile">
           <a role="button" class="btn btn-success col-9"
              @click="confirmOrder"
              :class="{ 'disabled': orderConfirmButtonDisabled }"
@@ -200,7 +200,7 @@
         <button @click="maybeConfirmOrder" class="btn btn-block btn-lg btn-success"
               :class="{ 'btn-warning' : showOrderWarning }"
               :disabled="orderConfirmButtonDisabled"
-              v-if="!payWithPin || !<%= @sumup_enabled.to_s %>">
+              v-if="!payWithPin || !<%= @sumup_enabled.to_s %> || !isMobile">
         <span class="text-uppercase">
           Bestelling plaatsen
         </span>


### PR DESCRIPTION
iPadOS browsers now 'pretend' to be a desktop browser (i.e. their user agent is the same as that of a MacOS device). This causes the Sumup button to currently not show up on iPads, even though the sumup app is supported for iPads. This PR fixes that by using a [workaroud](https://stackoverflow.com/a/57924983) to check if a device is an iPad.