### PR TITLE
Allow CI pass with dependency vulnerabilities

### DIFF
--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -10,6 +10,9 @@ if [ "${TYPE}" = "lint" ] || [ "${TYPE}" = "" ]; then
   echo "--- :parcel: Brakeman"
   bundle exec brakeman -z --no-pager
 
+  echo "--- :ruby: Bundle audit"
+  gem install bundler-audit
+  bundle-audit update && bundle-audit check --ignore CVE-2015-9284 || true
   RAILS_ENV=test bundle exec rails db:create db:environment:set db:schema:load
   # Don't check DB consistency until solved: https://github.com/trptcolin/consistency_fail/issues/42
   # bundle exec consistency_fail

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -10,6 +10,7 @@ if [ "${TYPE}" = "lint" ] || [ "${TYPE}" = "" ]; then
   echo "--- :parcel: Brakeman"
   bundle exec brakeman -z --no-pager
 
+  RAILS_ENV=test bundle exec rails db:create db:environment:set db:schema:load
   # Don't check DB consistency until solved: https://github.com/trptcolin/consistency_fail/issues/42
   # bundle exec consistency_fail
 

--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -10,10 +10,6 @@ if [ "${TYPE}" = "lint" ] || [ "${TYPE}" = "" ]; then
   echo "--- :parcel: Brakeman"
   bundle exec brakeman -z --no-pager
 
-  echo "--- :ruby: Bundle audit"
-  gem install bundler-audit
-  bundle-audit update && bundle-audit check --ignore CVE-2015-9284
-  RAILS_ENV=test bundle exec rails db:create db:environment:set db:schema:load
   # Don't check DB consistency until solved: https://github.com/trptcolin/consistency_fail/issues/42
   # bundle exec consistency_fail
 


### PR DESCRIPTION
Although there is something to say for making checks fail when vulnerabilities are present, it also prevents rollout of other important fixes, and sometimes creates conflicts if dependency updates for vulnerabilities are split into multiple PRs.