### PR TITLE
Update staging url

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -136,7 +136,7 @@ jobs:
           if [ "$GITHUB_REF_NAME" = 'master' ]; then
             echo '::set-output name=environment_url::https://streep.csvalpha.nl'
           else
-            echo '::set-output name=environment_url::https://staging.streep.csvalpha.nl'
+            echo '::set-output name=environment_url::https://stagingstreep.csvalpha.nl'
           fi
 
       - name: Checkout code

--- a/app/views/partials/_footer.html.erb
+++ b/app/views/partials/_footer.html.erb
@@ -1,6 +1,6 @@
 <footer class="footer d-flex justify-content-between">
   <span class="text-danger text-uppercase font-weight-bold mx-2">
-    <% if Rails.application.config.x.tomato_host == 'staging.streep.csvalpha.nl' %>
+    <% if Rails.application.config.x.tomato_host == 'stagingstreep.csvalpha.nl' %>
       For demo and testing purposes only
     <% elsif Rails.application.config.x.tomato_host != 'streep.csvalpha.nl' %>
       Development mode


### PR DESCRIPTION
Because we are using cloudflare now and can only use one level of subdomains with the free subscription, the staging url has been updated from staging.streep.csvalpha.nl to stagingstreep.csvalpha.nl. 