### PR TITLE
Account for differences in iOS and Android Sumup APIs

### DIFF
--- a/app/javascript/packs/order_screen.js
+++ b/app/javascript/packs/order_screen.js
@@ -272,25 +272,20 @@ document.addEventListener('turbolinks:load', () => {
         sumupUrl() {
           let affilateKey = element.dataset.sumupKey;
           let callback = element.dataset.sumupCallback;
-          if (this.isMobile == 'android') {
-            return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&total=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&callback=${callback}`;
-          } else if (this.isMobile == 'ios') {
+          if (this.isIos) {
             return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&amount=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&callbacksuccess=${callback}&callbackfail=${callback}`;
+          } else {
+            return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&total=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&callback=${callback}`;
           }
         },
 
-        isMobile() {
-          let android = /Android|webOS|Opera Mini/i.test(navigator.userAgent)
-          let ios = /iPhone|iPad|iPod/i.test(navigator.userAgent) || // iOS
+        isIos() {
+          return /iPhone|iPad|iPod/i.test(navigator.userAgent) || // iOS
             (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1); // iPadOS
+        },
 
-          if (android) {
-            return 'android';
-          } else if (ios) {
-            return 'ios';
-          } else {
-            return false;
-          }
+        isMobile() {
+          return this.isIos || /Android|webOS|Opera Mini/i.test(navigator.userAgent);
         }
       },
 

--- a/app/javascript/packs/order_screen.js
+++ b/app/javascript/packs/order_screen.js
@@ -272,12 +272,25 @@ document.addEventListener('turbolinks:load', () => {
         sumupUrl() {
           let affilateKey = element.dataset.sumupKey;
           let callback = element.dataset.sumupCallback;
-          return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&total=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&callback=${callback}`;
+          if (this.isMobile == 'android') {
+            return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&total=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&callback=${callback}`;
+          } else if (this.isMobile == 'ios') {
+            return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&amount=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&callbacksuccess=${callback}&callbackfail=${callback}`;
+          }
         },
 
         isMobile() {
-          return /Android|webOS|iPhone|iPad|iPod|Opera Mini/i.test(navigator.userAgent) || // Android / iOS
+          let android = /Android|webOS|Opera Mini/i.test(navigator.userAgent)
+          let ios = /iPhone|iPad|iPod/i.test(navigator.userAgent) || // iOS
             (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1); // iPadOS
+
+          if (android) {
+            return 'android';
+          } else if (ios) {
+            return 'ios';
+          } else {
+            return false;
+          }
         }
       },
 


### PR DESCRIPTION
Apparently there are differences between the [iOS](https://github.com/sumup/sumup-ios-url-scheme/blob/master/README.md) and [Android](https://github.com/sumup/sumup-android-api/blob/master/README.md) Sumup APIs, because consistency is way too boring 🙄. This PR makes sure the Sumup app also opens properly with the amount filled in on iOS.