### PR TITLE
Skip success screen

### DIFF
--- a/app/javascript/packs/order_screen.js
+++ b/app/javascript/packs/order_screen.js
@@ -287,9 +287,9 @@ document.addEventListener('turbolinks:load', () => {
           let affilateKey = element.dataset.sumupKey;
           let callback = element.dataset.sumupCallback;
           if (this.isIos) {
-            return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&amount=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&callbacksuccess=${callback}&callbackfail=${callback}`;
+            return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&amount=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&skip-screen-success=true&callbacksuccess=${callback}&callbackfail=${callback}`;
           } else {
-            return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&total=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&callback=${callback}`;
+            return `sumupmerchant://pay/1.0?affiliate-key=${affilateKey}&total=${this.orderTotal}&currency=EUR&title=Bestelling SOFIA&skip-screen-success=true&callback=${callback}`;
           }
         },
 


### PR DESCRIPTION
Since we're already showing if a payment succeeded in SOFIA (https://github.com/csvalpha/sofia/blob/a93020d6dda0be97e759f1458590661723a4b039/app/controllers/activities_controller.rb#L116), there is no need for the Sumup success screen, it only adds more clicks to the payment process. 