### PR TITLE
Enable renovate for .html.erb files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>csvalpha/.github"]
+  "extends": ["github>csvalpha/.github"],
+  "packageRules": [
+    {
+      "matchManagers": ["html"],
+      "fileMatch": "\\.html\\.erb$"
+    }
+  ]
 }


### PR DESCRIPTION
I noticed renovate did not create PRs for CDN dependency updates (see https://github.com/csvalpha/sofia/blob/587e91359b0afc4d80f8e405c32ebca6026870de/app/views/layouts/application.html.erb#L19). This PR changes the config such that `.html.erb` files are matched by the `html` manager.