### PR TITLE
Reload orderscreen credit

### DIFF
--- a/app/controllers/credit_mutations_controller.rb
+++ b/app/controllers/credit_mutations_controller.rb
@@ -20,7 +20,7 @@ class CreditMutationsController < ApplicationController
         NewCreditMutationNotificationJob.perform_later(@mutation) if Rails.env.production? || Rails.env.staging?
         format.html { redirect_to which_redirect?, flash: { success: 'Inleg of mutatie aangemaakt' } }
         format.json do
-          render json: @mutation, include: { user: { methods: %i[credit avatar_thumb_or_default_url minor insufficient_credit can_order] } }
+          render json: @mutation, include: { user: { methods: User.orderscreen_json_includes } }
         end
 
       else

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -71,7 +71,7 @@ class OrdersController < ApplicationController
   end
 
   def json_includes
-    { user: { methods: %i[credit avatar_thumb_or_default_url minor insufficient_credit can_order] },
+    { user: { methods: User.orderscreen_json_includes },
       activity: { only: %i[id title] },
       order_rows: { only: [:id, :product_count, { product: { only: %i[id name credit] } }] } }
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,4 @@
-class UsersController < ApplicationController
+class UsersController < ApplicationController # rubocop:disable Metrics/ClassLength
   before_action :authenticate_user!
 
   after_action :verify_authorized

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,10 +27,14 @@ class UsersController < ApplicationController
     @user = User.includes(:credit_mutations, roles_users: :role).find(params[:id])
     authorize @user
 
-    @user_json = @user.to_json(only: %i[id name deactivated])
-    @new_mutation = CreditMutation.new(user: @user)
+    if request.format.json?
+      render json: @user.as_json(methods: User.orderscreen_json_includes)
+    else
+      @user_json = @user.to_json(only: %i[id name deactivated])
+      @new_mutation = CreditMutation.new(user: @user)
 
-    @new_user = @user
+      @new_user = @user
+    end
   end
 
   def create

--- a/app/javascript/packs/order_screen.js
+++ b/app/javascript/packs/order_screen.js
@@ -67,6 +67,21 @@ document.addEventListener('turbolinks:load', () => {
             this.orderRows = [];
           }
 
+          if (user !== null) {
+            // Reload user to get latest credit balance
+            this.$http.get('/users/'+user.id).then((response) => {
+              const user = response.body;
+              this.$set(this.users, this.users.indexOf(user), user);
+
+              // Selected user might have changed in the meantime
+              if (this.selectedUser && this.selectedUser.id == user.id) {
+                this.selectedUser = user;
+              }
+            }, (response) => {
+              this.handleXHRError(response);
+            });
+          }
+
           this.payWithCash = false;
           this.payWithPin = false;
           this.selectedUser = user;

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,6 +111,10 @@ class User < ApplicationRecord
         .group(:id).sum('product_count * price_per_product')
   end
 
+  def self.orderscreen_json_includes
+    %i[credit avatar_thumb_or_default_url minor insufficient_credit can_order]
+  end
+
   private
 
   def no_deactivation_when_nonzero_credit


### PR DESCRIPTION
Fixes #782 
Reloads the user, and with that his balance and if ordering is allowed, when a user is selected in the orderscreen.