### PR TITLE
Notify amber users of negative credit immediately

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -22,7 +22,7 @@ class OrdersController < ApplicationController
     current_credit = @order.user.credit
 
     if @order.save
-      if @order.user.provider == 'amber_oauth2' and @order.user.credit.negative? && current_credit.positive?
+      if (@order.user.provider == 'amber_oauth2') && @order.user.credit.negative? && current_credit.positive?
         # User's credit went from positive to negative
         UserCreditMailer.insufficient_credit_mail(current_user).deliver_later
       end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -19,10 +19,18 @@ class OrdersController < ApplicationController
     @order = Order.new(permitted_attributes.merge(created_by: current_user))
     authorize @order
 
+    current_credit = @order.user.credit
+
     if @order.save
+      if @order.user.provider == 'amber_oauth2' and @order.user.credit.negative? && current_credit.positive?
+        # User's credit went from positive to negative
+        UserCreditMailer.insufficient_credit_mail(current_user).deliver_later
+      end
+
       order_data = Order.includes(
         :order_rows, user: { orders: :order_rows }
       ).find(@order.id)
+
       order_data.user.current_activity = order_data.activity unless order_data.user.nil?
       render json: order_data.as_json(include: json_includes)
     else

--- a/app/jobs/credit_insufficient_notification_job.rb
+++ b/app/jobs/credit_insufficient_notification_job.rb
@@ -7,8 +7,10 @@ class CreditInsufficientNotificationJob < ApplicationJob
 
     users_with_insufficient_credit.each do |user|
       if user.email.present?
-        UserCreditMailer.insufficient_credit_mail(user).deliver_later
-        success_count += 1
+        if user.provider != 'amber_oauth2' # Amber users are notified immediately
+          UserCreditMailer.insufficient_credit_mail(user).deliver_later
+          success_count += 1
+        end
       else
         unnotifyable_users.append user.name
       end


### PR DESCRIPTION
Since amber users can now no longer order with negative credit at the start of an activity, it is nice if they are notified of their negative credit before the next activity, which is currently not always the case, since mails are always only sent on Thursday. This PR fixes this by sending an email immediately when a user moves from positive to negative credit