### PR TITLE
Use cdnurl renovate manager on erb files

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>csvalpha/.github"],
-  "html": {
+  "cdnurl": {
     "fileMatch": ["\\.html\\.erb$"]
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>csvalpha/.github"],
   "cdnurl": {
-    "fileMatch": ["\\.html\\.erb$"]
+    "fileMatch": ["\\.html\\.erb$"],
+    "prBodyNotes": "Note: make sure to update the integrity hashes before merging this PR."
   }
 }


### PR DESCRIPTION
Since the html manager seems to be unable to handle erb files, let's try the cdnurl manager. Only disadvantage is that we'll have to manually update integrity hashes, but at least we'll get reminders of dependency updates.

Again, this PR will also require a change to our global renovate config: https://github.com/csvalpha/.github/pull/3