### PR TITLE
Fix bugs

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -60,13 +60,7 @@ body {
 
 .b-table-details--item {
   .order-history--item-edit {
-    color: $gray-100;
-  }
-
-  &:hover {
-    .order-history--item-edit {
-      color: $gray-700;
-    }
+    color: $gray-700;
   }
 }
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,14 +27,17 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
     @user = User.includes(:credit_mutations, roles_users: :role).find(params[:id])
     authorize @user
 
-    if request.format.json?
-      render json: @user.as_json(methods: User.orderscreen_json_includes)
-    else
-      @user_json = @user.to_json(only: %i[id name deactivated])
-      @new_mutation = CreditMutation.new(user: @user)
+    @user_json = @user.to_json(only: %i[id name deactivated])
+    @new_mutation = CreditMutation.new(user: @user)
 
-      @new_user = @user
-    end
+    @new_user = @user
+  end
+
+  def json
+    @user = User.find(params[:id])
+    authorize @user
+
+    render json: @user.as_json(methods: User.orderscreen_json_includes)
   end
 
   def create

--- a/app/javascript/packs/order_screen.js
+++ b/app/javascript/packs/order_screen.js
@@ -69,7 +69,7 @@ document.addEventListener('turbolinks:load', () => {
 
           if (user !== null) {
             // Reload user to get latest credit balance
-            this.$http.get('/users/'+user.id).then((response) => {
+            this.$http.get('/users/'+user.id+'/json').then((response) => {
               const user = response.body;
               this.$set(this.users, this.users.indexOf(user), user);
 

--- a/app/javascript/packs/order_screen.js
+++ b/app/javascript/packs/order_screen.js
@@ -186,6 +186,7 @@ document.addEventListener('turbolinks:load', () => {
             } else {
               // re-set user to update credit
               this.setUser(response.body.user);
+              this.orderRows = [];
             }
 
             this.isSubmitting = false;

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -12,7 +12,11 @@ class UserPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.treasurer? || user&.main_bartender? || record == user
+    user&.treasurer? || record == user
+  end
+
+  def json?
+    user&.main_bartender? || show?
   end
 
   def activities?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -12,7 +12,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def show?
-    user&.treasurer? || record == user
+    user&.treasurer? || user&.main_bartender? || record == user
   end
 
   def activities?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     end
     member do
       get :activities
+      get :json
     end
   end
 


### PR DESCRIPTION
Fixes three bugs:
- Clicking on a person in the order screen, which should refresh its credit, results in 403 with main_bartender role (without treasurer role)
- When selecting 'remember person', order rows are not cleared after ordering
- Transaction edit button is only shown on hover (not touch screen friendly)