### PR TITLE
Fix credit mutation time in mail

### DIFF
--- a/app/mailers/user_credit_mailer.rb
+++ b/app/mailers/user_credit_mailer.rb
@@ -23,6 +23,7 @@ class UserCreditMailer < ApplicationMailer
     @title = 'Je saldo is bijgewerkt'
     @credit_mutation_amount = credit_mutation.amount
     @credit_mutation_description = credit_mutation.description
+    @credit_mutation_time = credit_mutation.created_at
 
     mail to: credit_mutation.user.email, subject: 'Je saldo is bijgewerkt'
   end

--- a/app/views/user_credit_mailer/new_credit_mutation_mail.html.erb
+++ b/app/views/user_credit_mailer/new_credit_mutation_mail.html.erb
@@ -1,5 +1,5 @@
 <p style="margin: 0;font-size: 16px;line-height: 20px">
-  Op <%= l Time.zone.now, format: :long %> is uw saldo bijgewerkt met
+  Op <%= l @credit_mutation_time, format: :long %> is uw saldo bijgewerkt met
   <%= number_to_currency(@credit_mutation_amount, unit: '€') %>.
   De reden hiervoor is: <%= @credit_mutation_description%>.
   <br />


### PR DESCRIPTION
The credit mutation mail currently displays the time at which the email is sent as the time of the credit mutation. Since the mail is queued for asynchronous delivery, this time can be off from the actual time of the mutation. This PR fixes that.