### PR TITLE
Add craft_beer product category

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,5 +1,5 @@
 class Product < ApplicationRecord
-  enum category: { beer: 0, non_alcoholic: 1, distilled: 2, wine: 3, food: 4, tobacco: 5 }
+  enum category: { beer: 0, craft_beer: 6, non_alcoholic: 1, distilled: 2, wine: 3, food: 4, tobacco: 5 }
 
   has_many :product_prices, dependent: :destroy
   has_many :price_lists, through: :product_prices, dependent: :restrict_with_error
@@ -10,7 +10,7 @@ class Product < ApplicationRecord
   accepts_nested_attributes_for :product_prices, allow_destroy: true
 
   def requires_age
-    %w[beer distilled wine tobacco].include? category
+    %w[beer craft_beer distilled wine tobacco].include? category
   end
 
   def t_category

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -10,6 +10,7 @@ nl:
       time_only: '%H:%M'
 
   beer: 'bier'
+  craft_beer: 'speciaalbier'
   non_alcoholic: 'niet-alcoholisch'
   distilled: 'gedestilleerd'
   wine: 'wijn'
@@ -26,6 +27,7 @@ nl:
 
   codes:
     beer: 8010
+    craft_beer: 8015
     non_alcoholic: 8020
     distilled: 8030
     wine: 8040

--- a/db/seeds/products.rb
+++ b/db/seeds/products.rb
@@ -1,4 +1,4 @@
-def seed_products # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+def seed_products # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
   products = []
 
   # rubocop:disable Style/WordArray

--- a/db/seeds/products.rb
+++ b/db/seeds/products.rb
@@ -2,7 +2,8 @@ def seed_products # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   products = []
 
   # rubocop:disable Style/WordArray
-  products_beer = ['Bier (glas)', 'Bier (pul)', 'Bier (pitcher)', 'Speciaalbier', '12+1']
+  products_beer = ['Bier (glas)', 'Bier (pul)', 'Bier (pitcher)', '12+1']
+  products_craft_beer = ['Speciaalbier', 'Speciaalbier (pul)']
   products_non_alcoholic = ['Fris', 'Fris (klein)', 'Red Bull']
   products_distilled = ['Sterke drank', 'Dure Whisky', 'Weduwe Joustra Beerenburg']
   products_wine = ['Wijn (glas)', 'Wijn (fles)']
@@ -12,6 +13,10 @@ def seed_products # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 
   products_beer.each do |name|
     products << Product.create(name: name, category: :beer)
+  end
+
+  products_craft_beer.each do |name|
+    products << Product.create(name: name, category: :craft_beer)
   end
 
   products_non_alcoholic.each do |name|

--- a/spec/factories/product.rb
+++ b/spec/factories/product.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :product do
     name { Faker::Book.title }
-    category { %i[beer non_alcoholic distilled wine food tobacco].sample }
+    category { %i[beer craft_beer non_alcoholic distilled wine food tobacco].sample }
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Product, type: :model do
 
   describe '#requires_age' do
     context 'when with requires age category' do
-      subject(:product) { create(:product, category: %w[beer distilled wine tobacco].sample) }
+      subject(:product) { create(:product, category: %w[beer craft_beer distilled wine tobacco].sample) }
 
       it { expect(product.requires_age).to be true }
     end


### PR DESCRIPTION
We would like to keep track of the craft beer revenue separately from normal beer. This PR adds a new category for that.