### PR TITLE
Fix retry of sumup transaction

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -101,11 +101,18 @@ class ActivitiesController < ApplicationController # rubocop:disable Metrics/Cla
     @sumup_key = Rails.application.config.x.sumup_key
     @sumup_enabled = @sumup_key.present?
 
-    @sumup_error_order = if params['sumup_error']
-                           Order.find(params['sumup_error'])
-                         else
-                           false
-                         end
+    if params['sumup_error']
+      sumup_order_id = params['sumup_error'].split('-').first
+      sumup_attempt = if params['sumup_error'].include? '-'
+                        params['sumup_error'].split('-').last.to_i
+                      else
+                        0
+                      end
+      @sumup_error_order = Order.find(sumup_order_id)
+      @sumup_tx_id = "#{sumup_order_id}-#{sumup_attempt + 1}"
+    else
+      @sumup_error_order = false
+    end
 
     # Set flags for application.html.slim
     @show_navigationbar = false

--- a/app/views/activities/order_screen.html.erb
+++ b/app/views/activities/order_screen.html.erb
@@ -76,7 +76,7 @@
 
   <% if @sumup_error_order %>
     <b-modal id="sumup-error-modal" ref="sumupErrorModal" title="Sumup betaling mislukt" 
-             ok-title="Nog eens proberen" @ok="startSumupPayment(<%= @sumup_error_order.id %>, <%= @sumup_error_order.order_total %>)" 
+             ok-title="Nog eens proberen" @ok="startSumupPayment('<%= @sumup_tx_id %>', <%= @sumup_error_order.order_total %>)" 
              cancel-title="Bestelling verwijderen" @cancel="deleteOrder(<%= @sumup_error_order.id %>)">
       <div class="modal-body">
         De Sumup betaling is mislukt. Wil je de betaling nogmaals proberen of de bestelling verwijderen?


### PR DESCRIPTION
Fixes #840 
On retrying a transaction, an attempt number is added to the transaction id (e.g. transaction 105 becomes 105-1, 105-2, 105-n on the nth retry)