### PR TITLE
Fixed error in mailing invoices

### DIFF
--- a/app/mailers/invoice_mailer.rb
+++ b/app/mailers/invoice_mailer.rb
@@ -6,7 +6,7 @@ class InvoiceMailer < ApplicationMailer
     @cab_text = 'iDeal betaling'
 
     attachments["#{invoice.human_id}.pdf"] = WickedPdf.new.pdf_from_string(
-      render_to_string(pdf: invoice.human_id.to_s, template: 'invoices/show.html.erb', layout: 'pdf.html.erb')
+      render_to_string(pdf: invoice.human_id.to_s, template: 'invoices/show', layout: 'pdf')
     )
 
     mail to: @invoice.email, subject: "Factuur #{invoice.human_id} #{Rails.application.config.x.company_name}"


### PR DESCRIPTION
Either wicked_pdf or rails updated, which changed the parameters of `render_to_string` in such a way that they only work without file extensions, otherwise it cannot find the templates. When removing the extensions, Sofia no longer shows an error and shows the banner that the invoice was sent succesfully.

I could not test whether the pdf in the sent mail is still correct now, as I could not figure out how to catch sent mails locally.