### PR TITLE
Made price-lists table scrollable and made lists archivable

### DIFF
--- a/app/assets/stylesheets/price_lists.scss
+++ b/app/assets/stylesheets/price_lists.scss
@@ -1,35 +1,35 @@
 @import 'theme_sofia';
 
-.price_lists_table {
-  max-height: calc(100vh - 18rem);
+.price-lists-table {
   width: fit-content;
+  max-height: calc(100vh - 18rem);
 
   .center-text {
     margin: 0 auto;
     text-align: center;
   }
 
-  .products-id, 
+  .products-id,
   .products-cancel-edit {
-    width: 1.75rem;
     left: 0;
+    width: 1.75rem;
   }
 
   .products-name {
-    width: 6rem; 
     left: 2.1rem;
+    width: 6rem;
   }
 
-  .products-actions, 
-  .products-new-edit-button, 
+  .products-actions,
+  .products-new-edit-button,
   .products-save-new {
     right: 0;
   }
 
-  .products-id, 
-  .products-cancel-edit, 
-  .products-name, 
-  .products-new-edit-button, 
+  .products-id,
+  .products-cancel-edit,
+  .products-name,
+  .products-new-edit-button,
   .products-save-new {
     position: sticky;
     z-index: 1;
@@ -42,10 +42,10 @@
   }
 
   thead  {
-    background-color: $body-bg;
     position: sticky;
     top: 0;
     z-index: 2;
+    background-color: $body-bg;
   }
 
   th {

--- a/app/assets/stylesheets/price_lists.scss
+++ b/app/assets/stylesheets/price_lists.scss
@@ -1,21 +1,59 @@
 @import 'theme_sofia';
 
-.center-text {
-  margin: 0 auto;
-  text-align: center;
-}
-
-th {
-  &.products-id {
-    width: 1.75rem;
-  }
-
-  &.products-actions {
-    width: 4rem;
-  }
-}
-
 .price_lists_table {
+  max-height: calc(100vh - 18rem);
+  width: fit-content;
+
+  .center-text {
+    margin: 0 auto;
+    text-align: center;
+  }
+
+  .products-id, 
+  .products-cancel-edit {
+    width: 1.75rem;
+    left: 0;
+  }
+
+  .products-name {
+    width: 6rem; 
+    left: 2.1rem;
+  }
+
+  .products-actions, 
+  .products-new-edit-button, 
+  .products-save-new {
+    right: 0;
+  }
+
+  .products-id, 
+  .products-cancel-edit, 
+  .products-name, 
+  .products-new-edit-button, 
+  .products-save-new {
+    position: sticky;
+    z-index: 1;
+    background-color: $body-bg;
+  }
+
+  .products-actions {
+    position: sticky;
+    z-index: 1;
+  }
+
+  thead  {
+    background-color: $body-bg;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
+
+  th {
+    &.products-actions {
+      width: 4rem;
+    }
+  }
+
   tr {
     &:last-child {
       td {
@@ -23,38 +61,39 @@ th {
       }
     }
   }
-}
 
-td {
-  &.products-new-edit-button {
-    padding: .5rem 1rem;
-  }
 
-  &.products-new {
-    input {
-      &.form-control {
-        width: 6rem;
+  td {
+    &.products-new-edit-button {
+      padding: .5rem 1rem;
+    }
+
+    &.products-new {
+      input {
+        &.form-control {
+          width: 6rem;
+        }
+      }
+
+      select {
+        &.form-control {
+          width: 4rem;
+        }
       }
     }
 
-    select {
-      &.form-control {
-        width: 4rem;
+    &.products-new-price {
+      input {
+        &.form-control {
+          width: 4rem;
+        }
       }
     }
-  }
 
-  &.products-new-price {
-    input {
-      &.form-control {
-        width: 2rem;
-      }
+    &.products-cancel-new,
+    &.products-cancel-edit,
+    &.products-save-new {
+      vertical-align: middle;
     }
-  }
-
-  &.products-cancel-new,
-  &.products-cancel-edit,
-  &.products-save-new {
-    vertical-align: middle;
   }
 }

--- a/app/controllers/price_lists_controller.rb
+++ b/app/controllers/price_lists_controller.rb
@@ -63,7 +63,7 @@ class PriceListsController < ApplicationController
     authorize @price_list
 
     @price_list.archived_at = nil
-    
+
     respond_to do |format|
       if @price_list.save
         format.json { render json: @price_list.archived_at }

--- a/app/controllers/price_lists_controller.rb
+++ b/app/controllers/price_lists_controller.rb
@@ -4,14 +4,14 @@ class PriceListsController < ApplicationController
   after_action :verify_authorized
 
   def index
-    recent_price_lists = PriceList.order(created_at: :desc).limit(6)
+    price_lists = PriceList.order(created_at: :desc)
     products = Product.all.order(:id).includes(:product_prices)
 
-    authorize recent_price_lists
+    authorize price_lists
 
     @price_list = PriceList.new
 
-    @recent_price_lists_json = recent_price_lists.to_json(except: %i[created_at updated_at deleted_at])
+    @price_lists_json = price_lists.to_json(except: %i[created_at updated_at deleted_at])
     @products_json = products.to_json(
       include: { product_prices: { except: %i[created_at updated_at deleted_at] } },
       methods: :t_category,
@@ -41,6 +41,36 @@ class PriceListsController < ApplicationController
       flash[:error] = "Prijslijst wijzigen mislukt; #{@price_list.errors.full_messages.join(', ')}"
     end
     redirect_to @price_list
+  end
+
+  def archive
+    @price_list = PriceList.find(params[:id])
+    authorize @price_list
+
+    @price_list.archived_at = Time.zone.now
+
+    respond_to do |format|
+      if @price_list.save
+        format.json { render json: @price_list.archived_at }
+      else
+        format.json { render json: @price_list.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def unarchive
+    @price_list = PriceList.find(params[:id])
+    authorize @price_list
+
+    @price_list.archived_at = nil
+    
+    respond_to do |format|
+      if @price_list.save
+        format.json { render json: @price_list.archived_at }
+      else
+        format.json { render json: @price_list.errors, status: :unprocessable_entity }
+      end
+    end
   end
 
   private

--- a/app/policies/price_list_policy.rb
+++ b/app/policies/price_list_policy.rb
@@ -15,6 +15,14 @@ class PriceListPolicy < ApplicationPolicy
     create?
   end
 
+  def archive?
+    create?
+  end
+
+  def unarchive?
+    create?
+  end
+
   def search?
     index?
   end

--- a/app/views/price_lists/index.html.erb
+++ b/app/views/price_lists/index.html.erb
@@ -3,7 +3,8 @@
   <%= render 'modal' %>
 <% end %>
 
-<div class="container footer-padding">
+<%= content_tag :div, id: "pricelists-container", class: "container footer-padding",
+  data: {price_lists: @price_lists_json, products: @products_json} do %>
   <div class="row">
     <div class="col-sm-12 mt-4">
       <h1>
@@ -11,29 +12,34 @@
       </h1>
       <div class="d-flex justify-content-between mb-3 align-items-center flex-wrap">
         <span class="my-1">
-          Hier worden de vijf nieuwste prijslijsten en alle producten getoond.
+          Hier worden alle prijslijsten en alle producten getoond.
         </span>
         <button class="btn btn-sm btn-primary" data-bs-target="#editPriceListModal" data-bs-toggle="modal" role="button">
           <%= fa_icon 'plus', class: 'me-1' %>
           Nieuwe prijslijst
         </button>
       </div>
-
-      <%= content_tag :table, id: 'price_lists_table', class: 'price_lists_table table table-striped table-responsive-md',
-                      data: {price_lists: @recent_price_lists_json, products: @products_json} do %>
+      <div class="form-check">
+        <input class="form-check-input" type="checkbox" id="show-archived-check" v-model="showArchived">
+        <label class="form-check-label" for="show-archived-check">
+          Laat gearchieveerde prijslijsten zien 
+        </label>
+      </div>
+      
+      <table id='price_lists_table' class='price_lists_table table table-striped overflow-scroll mw-100 mx-auto d-block'>
         <thead class="table-header-rotated products">
         <tr>
           <th class="products-id" scope="col">ID</th>
           <th class="products-name" scope="col">Product</th>
           <th class="products-category" scope="col">Categorie</th>
-          <th class="products-pricelist rotate" scope="col" v-for="priceList in priceLists">
+          <th class="products-pricelist rotate" scope="col" v-for="priceList in filteredPriceLists">
             <div class="center-text" v-bind:title="priceList.name">
               <span>
                 {{ priceList.name }}
               </span>
             </div>
           </th>
-          <th class="products-actions" v-if="priceLists.length > 0">
+          <th class="products-actions" v-if="filteredPriceLists.length > 0">
           </th>
         </tr>
         </thead>
@@ -48,12 +54,12 @@
                 <%= fa_icon 'times lg' %>
               </span>
             </td>
-            <td class="products-new">
+            <td class="products-new products-name">
               <div class="d-flex">
                 <input class="form-control flex-grow-1" placeholder="Productnaam" type="text" v-model="product.name" :disabled="product.id"/>
               </div>
             </td>
-            <td class="products-new">
+            <td class="products-new products-category">
               <div class="d-flex">
                 <select class="form-select flex-grow-1" v-model="product.category">
                   <% Product.categories.each do |category| %>
@@ -66,7 +72,7 @@
                 </select>
               </div>
             </td>
-            <td class="products-new-price" v-for="priceList in priceLists">
+            <td class="products-new-price" v-for="priceList in filteredPriceLists">
               <div class="d-flex">
                 <input class="form-control flex-grow-1" placeholder="2.18" type="text" v-model="findPrice(product, priceList).price"/>
               </div>
@@ -77,15 +83,15 @@
             </span></td>
           </template>
           <template v-else="">
-            <th scope="row">{{ product.id }}</th>
-            <td>{{ product.name }}</td>
-            <td>{{ product.t_category }}</td>
-            <td class="product-price center-text" v-for="priceList in priceLists">
-              <span v-bind:title="product.name + ' in lijst ' + priceList.name">
+            <th class="products-id" scope="row">{{ product.id }}</th>
+            <td class="products-name">{{ product.name }}</td>
+            <td class="products-category">{{ product.t_category }}</td>
+            <td class="product-price center-text" v-for="priceList in filteredPriceLists">
+              <span class="text-nowrap" v-bind:title="product.name + ' in lijst ' + priceList.name">
                 {{ productPriceToCurrency(findPrice(product, priceList)) }}
               </span>
             </td>
-            <td class="products-new-edit-button" v-if="priceLists.length > 0">
+            <td class="products-new-edit-button" v-if="filteredPriceLists.length > 0">
               <button class="btn btn-sm btn-outline-secondary" v-on:click="editProduct(product)">
                 <%= fa_icon 'pencil' %>
               </button>
@@ -93,7 +99,7 @@
           </template>
         </tr>
         <tr>
-          <td colspan="2">
+          <td colspan="3">
             <div class="d-grid">
               <button class="btn btn-secondary btn-sm products-button-new" v-on:click.prevent="newProduct">
                 Voeg een nieuw product toe
@@ -101,10 +107,18 @@
               </button>
             </div>
           </td>
-          <td colspan="8"></td>
+          <td class="products-archive-button center-text" v-for="priceList in filteredPriceLists">
+          <button class="btn btn-sm btn-outline-secondary" v-if="priceList.archived_at" v-on:click="unarchivePriceList(priceList)">
+            <%= fa_icon 'repeat' %>
+          </button>
+          <button class="btn btn-sm btn-outline-secondary" v-else="" v-on:click="archivePriceList(priceList)">
+            <%= fa_icon 'archive' %>
+          </button>
+          </td>
         </tr>
         </tbody>
-      <% end %>
+      </table>
     </div>
   </div>
 </div>
+<% end %>

--- a/app/views/price_lists/index.html.erb
+++ b/app/views/price_lists/index.html.erb
@@ -26,7 +26,7 @@
         </label>
       </div>
       
-      <table id='price_lists_table' class='price_lists_table table table-striped overflow-scroll mw-100 mx-auto d-block'>
+      <table id='price-lists-table' class='price-lists-table table table-striped overflow-scroll mw-100 mx-auto d-block'>
         <thead class="table-header-rotated products">
         <tr>
           <th class="products-id" scope="col">ID</th>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,12 @@ Rails.application.routes.draw do
   end
 
   resources :orders, only: %i[index create update destroy]
-  resources :price_lists, only: %i[index create update]
+  resources :price_lists, only: %i[index create update] do
+    member do
+      post :archive
+      post :unarchive
+    end
+  end
 
   resources :users, only: %i[index show create update] do
     collection do

--- a/db/migrate/20240202124405_add_archived_at_to_price_list.rb
+++ b/db/migrate/20240202124405_add_archived_at_to_price_list.rb
@@ -1,0 +1,5 @@
+class AddArchivedAtToPriceList < ActiveRecord::Migration[7.0]
+  def change
+    add_column :price_lists, :archived_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_12_161008) do
-
+ActiveRecord::Schema[7.0].define(version: 2024_02_02_124405) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,8 +49,8 @@ ActiveRecord::Schema.define(version: 2022_10_12_161008) do
     t.integer "amount", null: false
     t.decimal "price", precision: 8, scale: 2, null: false
     t.datetime "deleted_at"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["invoice_id"], name: "index_invoice_rows_on_invoice_id"
   end
 
@@ -115,6 +114,7 @@ ActiveRecord::Schema.define(version: 2022_10_12_161008) do
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "archived_at"
   end
 
   create_table "product_prices", force: :cascade do |t|


### PR DESCRIPTION
The treasurerwanted to be able to see more than 6 pricelists, so the pricelist table at `/price_lists` was made scrollable for that.

To not show old and irrelevant pricelists, the treasurer can now 'archive' pricelists, which simply hides them from the table.

To archive a pricelist, the red circled button in the image below can be pressed:
![image](https://github.com/csvalpha/sofia/assets/101463776/cfb7e241-f95b-41a3-a596-3a5549af1ead)

To view all pricelist, the treasure can check the "Laat gearchieveerde prijslijsten zien" box:
![image](https://github.com/csvalpha/sofia/assets/101463776/9c6130bf-2dd5-4b4f-8c21-8954bc00a1d2)

When viewing all pricelists, archived pricelists can be unarchived with the red circled button in the image below:
![image](https://github.com/csvalpha/sofia/assets/101463776/eba5b3a9-da11-4a14-b12e-c8a82055aa26)

