### PR TITLE
Make product name mutable again

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -6,7 +6,6 @@ class Product < ApplicationRecord
   has_many :price_lists, through: :product_prices, dependent: :restrict_with_error
 
   validates :name, :category, presence: true
-  validate :name_readonly
 
   accepts_nested_attributes_for :product_prices, allow_destroy: true
 
@@ -16,13 +15,5 @@ class Product < ApplicationRecord
 
   def t_category
     I18n.t category
-  end
-
-  private
-
-  def name_readonly
-    return if new_record?
-
-    errors.add(:name, 'is readonly') if name_changed?
   end
 end

--- a/app/views/price_lists/index.html.erb
+++ b/app/views/price_lists/index.html.erb
@@ -25,11 +25,11 @@
         <div class="form-check">
           <input class="form-check-input" type="checkbox" id="show-archived-check" v-model="showArchived">
           <label class="form-check-label" for="show-archived-check">
-            Laat gearchieveerde prijslijsten zien 
+            Laat gearchieveerde prijslijsten zien
           </label>
         </div>
       <% end %>
-      
+
       <table id='price-lists-table' class='price-lists-table table table-striped overflow-scroll mw-100 mx-auto d-block pe-2'>
         <thead class="table-header-rotated products">
         <tr>
@@ -60,7 +60,7 @@
             </td>
             <td class="products-new products-name">
               <div class="d-flex">
-                <input class="form-control flex-grow-1" placeholder="Productnaam" type="text" v-model="product.name" :disabled="product.id"/>
+                <input class="form-control flex-grow-1" placeholder="Productnaam" type="text" v-model="product.name">
               </div>
             </td>
             <td class="products-new products-category">

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe Product, type: :model do
 
       it { expect(product).not_to be_valid }
     end
-
-    context 'when updating the name' do
-      subject(:product) { create(:product) }
-
-      it { expect(product.update(name: 'new_name')).to be false }
-    end
   end
 
   describe '#requires_age' do


### PR DESCRIPTION
fixes #937 
Basically reverts #598 

The concern with #595 was that users were modifying product names when they really just wanted to create a new product. Should we provide the user with a warning, like a tooltip or a dialog?
