### PR TITLE
Remove packs/js file path leftover from webpacker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,7 +25,6 @@ yarn-error.log
 /tmp
 /public/system
 /public/assets
-/public/packs-test
 /coverage
 /spec/tmp
 

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -81,7 +81,7 @@ jobs:
         env:
           IMAGE_NAME: ${{ fromJSON(steps.build_push_image.outputs.metadata)['image.name'] }}
         run: |
-          docker cp "$(docker create "$IMAGE_NAME")":/app/public/packs/js/. sourcemaps
+          docker cp "$(docker create "$IMAGE_NAME")":/app/public/assets/. sourcemaps
 
       - name: Create Sentry release
         if: ${{ !(github.event_name == 'workflow_dispatch' && github.workflow == 'Publish Image') }}
@@ -94,7 +94,7 @@ jobs:
           finalize: false
           sourcemaps: sourcemaps
           version: ${{ inputs.sha }}
-          url_prefix: ~/packs/js/
+          url_prefix: ~/assets
 
   update_check_run:
     name: Update Check Run

--- a/.gitignore
+++ b/.gitignore
@@ -32,8 +32,6 @@
 !/.yarn/versions
 yarn-error\.log
 /public/assets
-/public/packs
-/public/packs-test
 /node_modules
 yarn-debug.log*
 .yarn-integrity

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,6 @@ export default [
     ignores: [
       "app/assets/builds/",
       "node_modules/",
-      "public/packs/",
       "public/assets/",
       "vendor/",
       "tmp/",


### PR DESCRIPTION
### Checklist

- [ ] Merged database migrations into 1 database migration.
- [ ] Tested database migrations from `origin/staging` (`git checkout staging ; git pull ; bundle exec rails db:reset ; git checkout BRANCH ; bundle exec rails db:migrate`).

### Summary

Shortly summarize the changes in this pull request. Does it concern changes in the UI, add some screenshots. Are there related issues solved? Please, mention them (with 'fixes #xyz', see https://github.com/blog/1506-closing-issues-via-pull-requests), so they can be resolved automatically when merging this pull request.

### Other information

If there is some other relevant and important information for this pull request, mention it here. For example, related pull requests or newly introduced conventions, packages or other dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated asset extraction and Sentry integration paths to streamline error tracking and debugging.
  * Refined build configuration to optimize artifact handling and tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->