### PR TITLE
Remove the user sync button and related code

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -97,19 +97,6 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
     redirect_to @user
   end
 
-  def refresh_user_list
-    authorize User
-
-    users_json.each do |user_json|
-      find_or_create_user(user_json)
-    end
-
-    users_not_in_json = User.active.in_amber.where.not(uid: users_json.pluck('id')).where.not(name: 'Streepsysteem Flux')
-    users_not_in_json.each(&:archive!)
-
-    redirect_to users_path
-  end
-
   def search
     authorize User
 
@@ -164,11 +151,6 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   private
-
-  def users_json
-    JSON.parse(RestClient.get("#{Rails.application.config.x.amber_api_url}/api/v1/users?filter[group]=Leden",
-                              'Authorization' => "Bearer #{api_token}"))['data']
-  end
 
   def find_or_create_user(user_json) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     fields = user_json['attributes']

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -3,10 +3,6 @@ class UserPolicy < ApplicationPolicy
     user&.treasurer? || user&.renting_manager? || user&.main_bartender?
   end
 
-  def refresh_user_list?
-    user&.treasurer?
-  end
-
   def search?
     index?
   end

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -27,14 +27,6 @@
     <% if Rails.application.config.x.amber_api_host.present? %>
       <div class="d-flex justify-content-between align-items-center">
         <h3><%= Rails.application.config.x.site_association %> gebruikers</h3>
-        <% if policy(User).refresh_user_list? %>
-          <span>
-            <%= link_to refresh_user_list_users_path, class: 'btn btn-primary btn-sm me-1' do %>
-              <i class="fas fa-arrows-rotate"></i>
-              <span class="d-none d-md-inline ms-1">Synchroniseer gebruikers</span>
-            <% end %>
-          </span>
-        <% end %>
       </div>
       <users-table :users="amber_users" class="mb-5"></users-table>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,6 @@ Rails.application.routes.draw do
 
   resources :users, only: %i[index show create update] do
     collection do
-      get :refresh_user_list
       post :search
     end
     member do


### PR DESCRIPTION
This is remove because the functionaly is brokenen and not usefull to the treasurer
Fixes https://github.com/csvalpha/sofia/issues/162 by not having the code anymore
Fixes https://github.com/csvalpha/sofia/issues/908 by not having the code anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed the user synchronization capability that allowed refreshing external user data and the associated refresh control from the user management interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->