### PR TITLE
move Permited Atributes to Policy

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -45,7 +45,7 @@ class ActivitiesController < ApplicationController # rubocop:disable Metrics/Cla
   end
 
   def create
-    @activity = Activity.new(permitted_attributes.merge(created_by: current_user))
+    @activity = Activity.new(activity_params.merge(created_by: current_user))
     authorize @activity
 
     if @activity.save
@@ -61,7 +61,7 @@ class ActivitiesController < ApplicationController # rubocop:disable Metrics/Cla
     @activity = Activity.find(params[:id])
     authorize @activity
 
-    if @activity.update(params.require(:activity).permit(%i[title]))
+    if @activity.update(activity_params_for_update)
       flash[:success] = 'Activiteit hernoemd'
     else
       flash[:error] = "Activiteit hernoemen mislukt; #{@activity.errors.full_messages.join(', ')}"
@@ -177,7 +177,11 @@ class ActivitiesController < ApplicationController # rubocop:disable Metrics/Cla
     activity.price_list.product_price.sort_by { |p| p.product.id }
   end
 
-  def permitted_attributes
-    params.require(:activity).permit(%i[title start_time end_time price_list_id])
+  def activity_params
+    params.require(:activity).permit(policy(Activity).permitted_attributes)
+  end
+
+  def activity_params_for_update
+    params.require(:activity).permit(policy(@activity).permitted_attributes_for_update)
   end
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -178,7 +178,7 @@ class ActivitiesController < ApplicationController # rubocop:disable Metrics/Cla
   end
 
   def activity_params
-    params.require(:activity).permit(policy(Activity).permitted_attributes)
+    params.require(:activity).permit(policy(Activity.new).permitted_attributes)
   end
 
   def activity_params_for_update

--- a/app/controllers/credit_mutations_controller.rb
+++ b/app/controllers/credit_mutations_controller.rb
@@ -14,7 +14,7 @@ class CreditMutationsController < ApplicationController
   end
 
   def create # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
-    @mutation = CreditMutation.new(permitted_attributes.merge(created_by: current_user))
+    @mutation = CreditMutation.new(credit_mutation_params.merge(created_by: current_user))
     authorize @mutation
 
     respond_to do |format|
@@ -40,7 +40,7 @@ class CreditMutationsController < ApplicationController
     %i[user activity created_by]
   end
 
-  def permitted_attributes
-    params.require(:credit_mutation).permit(%i[description amount user_id activity_id])
+  def credit_mutation_params
+    params.require(:credit_mutation).permit(policy(CreditMutation).permitted_attributes)
   end
 end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -81,6 +81,6 @@ class InvoicesController < ApplicationController
   end
 
   def invoice_params
-    params.require(:invoice).permit(policy(Invoice).permitted_attributes)
+    params.require(:invoice).permit(policy(Invoice.new).permitted_attributes)
   end
 end

--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -27,7 +27,7 @@ class InvoicesController < ApplicationController
   end
 
   def create
-    attributes = remove_empty(permitted_attributes.to_h)
+    attributes = remove_empty(invoice_params.to_h)
     @invoice = Invoice.new(attributes)
     authorize @invoice
 
@@ -80,7 +80,7 @@ class InvoicesController < ApplicationController
     @invoice = Invoice.find_by!(token: params[:id])
   end
 
-  def permitted_attributes
-    params.require(:invoice).permit(%i[user_id activity_id name_override email_override rows], rows_attributes: %i[name amount price])
+  def invoice_params
+    params.require(:invoice).permit(policy(Invoice).permitted_attributes)
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -84,7 +84,7 @@ class OrdersController < ApplicationController
   end
 
   def order_params
-    params.require(:order).permit(policy(Order).permitted_attributes_for_create)
+    params.require(:order).permit(policy(Order.new).permitted_attributes_for_create)
   end
 
   def order_params_for_update

--- a/app/controllers/price_lists_controller.rb
+++ b/app/controllers/price_lists_controller.rb
@@ -21,7 +21,7 @@ class PriceListsController < ApplicationController
   end
 
   def create
-    @price_list = PriceList.new(permitted_attributes)
+    @price_list = PriceList.new(price_list_params)
     authorize @price_list
 
     if @price_list.save
@@ -36,7 +36,7 @@ class PriceListsController < ApplicationController
     @price_list = PriceList.find(params[:id])
     authorize @price_list
 
-    if @price_list.update(permitted_attributes)
+    if @price_list.update(price_list_params)
       flash[:success] = 'Prijslijst opgeslagen'
     else
       flash[:error] = "Prijslijst wijzigen mislukt; #{@price_list.errors.full_messages.join(', ')}"
@@ -76,7 +76,7 @@ class PriceListsController < ApplicationController
 
   private
 
-  def permitted_attributes
-    params.require(:price_list).permit(:name)
+  def price_list_params
+    params.require(:price_list).permit(policy(PriceList).permitted_attributes)
   end
 end

--- a/app/controllers/price_lists_controller.rb
+++ b/app/controllers/price_lists_controller.rb
@@ -77,6 +77,6 @@ class PriceListsController < ApplicationController
   private
 
   def price_list_params
-    params.require(:price_list).permit(policy(PriceList).permitted_attributes)
+    params.require(:price_list).permit(policy(PriceList.new).permitted_attributes)
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -5,7 +5,7 @@ class ProductsController < ApplicationController
   after_action :verify_authorized
 
   def create
-    @product = Product.new(permitted_attributes)
+    @product = Product.new(product_params)
     authorize @product
 
     if @product.save
@@ -18,7 +18,7 @@ class ProductsController < ApplicationController
   def update
     authorize @product
 
-    if @product.update(permitted_attributes)
+    if @product.update(product_params)
       render json: @product, include: json_includes, except: json_exludes, methods: :t_category
     else
       render json: @product.errors, status: :unprocessable_content
@@ -31,10 +31,8 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
   end
 
-  def permitted_attributes
-    params.require(:product)
-          .permit(%i[name category color requires_age id],
-                  product_prices_attributes: %i[id product_id price_list_id price _destroy])
+  def product_params
+    params.require(:product).permit(policy(Product).permitted_attributes)
   end
 
   def json_includes

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -32,7 +32,7 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params.require(:product).permit(policy(Product).permitted_attributes)
+    params.require(:product).permit(policy(Product.new).permitted_attributes)
   end
 
   def json_includes

--- a/app/controllers/sofia_accounts_controller.rb
+++ b/app/controllers/sofia_accounts_controller.rb
@@ -257,6 +257,6 @@ class SofiaAccountsController < ApplicationController # rubocop:disable Metrics/
   end
 
   def sofia_account_params
-    params.require(:sofia_account).permit(policy(SofiaAccount).permitted_attributes)
+    params.require(:sofia_account).permit(policy(SofiaAccount.new).permitted_attributes)
   end
 end

--- a/app/controllers/sofia_accounts_controller.rb
+++ b/app/controllers/sofia_accounts_controller.rb
@@ -15,7 +15,7 @@ class SofiaAccountsController < ApplicationController # rubocop:disable Metrics/
     user = User.find_by(id: user_id)
     validate_user(user)
 
-    sofia_account = SofiaAccount.new(permitted_attributes.merge(user_id:))
+    sofia_account = SofiaAccount.new(sofia_account_params.merge(user_id:))
     raise normalize_error_messages(sofia_account.errors.full_messages) unless sofia_account.save
 
     update_user_after_creation(user, sofia_account)
@@ -256,7 +256,7 @@ class SofiaAccountsController < ApplicationController # rubocop:disable Metrics/
     raise normalize_error_messages(user.errors.full_messages)
   end
 
-  def permitted_attributes
-    params.require(:sofia_account).permit(%i[username password password_confirmation])
+  def sofia_account_params
+    params.require(:sofia_account).permit(policy(SofiaAccount).permitted_attributes)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -166,6 +166,6 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def user_params
-    params.require(:user).permit(policy(User).permitted_attributes)
+    params.require(:user).permit(policy(User.new).permitted_attributes)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -88,7 +88,7 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
     @user = User.find(params[:id])
     authorize @user
 
-    if @user.update(params.require(:user).permit(policy(@user).permitted_attributes_for_update))
+    if update_user
       flash[:success] = 'Gebruiker geupdate'
     else
       flash[:error] = "Gebruiker updaten mislukt; #{@user.errors.full_messages.join(', ')}"
@@ -150,6 +150,11 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   private
+
+  def update_user
+    permitted_params = params.require(:user).permit(policy(@user).permitted_attributes_for_update)
+    @user.update(permitted_params)
+  end
 
   def find_or_create_user(user_json) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     fields = user_json['attributes']

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -72,7 +72,7 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
   end
 
   def create
-    @user = User.new(permitted_attributes)
+    @user = User.new(user_params)
     authorize @user
 
     if @user.save
@@ -88,7 +88,7 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
     @user = User.find(params[:id])
     authorize @user
 
-    if @user.update(params.require(:user).permit(%i[name email deactivated]))
+    if @user.update(params.require(:user).permit(policy(@user).permitted_attributes_for_update))
       flash[:success] = 'Gebruiker geupdate'
     else
       flash[:error] = "Gebruiker updaten mislukt; #{@user.errors.full_messages.join(', ')}"
@@ -140,8 +140,7 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
     end
     authorize @sofia_account
 
-    if @user.update(params.require(:user).permit(%i[email sub_provider] + (current_user.treasurer? ? %i[name deactivated] : []),
-                                                 sofia_account_attributes: %i[id username]))
+    if @user.update(params.require(:user).permit(policy(@user).permitted_attributes_for_update_with_sofia_account))
       flash[:success] = 'Gegevens gewijzigd'
     else
       flash[:error] = "Gegevens wijzigen mislukt; #{@user.errors.full_messages.join(', ')}"
@@ -166,7 +165,7 @@ class UsersController < ApplicationController # rubocop:disable Metrics/ClassLen
     u.save
   end
 
-  def permitted_attributes
-    params.require(:user).permit(%w[name email provider sub_provider])
+  def user_params
+    params.require(:user).permit(policy(User).permitted_attributes)
   end
 end

--- a/app/policies/activity_policy.rb
+++ b/app/policies/activity_policy.rb
@@ -48,4 +48,12 @@ class ActivityPolicy < ApplicationPolicy
   def credit_mutations?
     user&.treasurer?
   end
+
+  def permitted_attributes
+    %i[title start_time end_time price_list_id]
+  end
+
+  def permitted_attributes_for_update
+    %i[title]
+  end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -38,6 +38,10 @@ class ApplicationPolicy
     Pundit.policy_scope!(user, record.class)
   end
 
+  def permitted_attributes
+    []
+  end
+
   class Scope
     attr_reader :user, :scope
 

--- a/app/policies/credit_mutation_policy.rb
+++ b/app/policies/credit_mutation_policy.rb
@@ -16,4 +16,8 @@ class CreditMutationPolicy < ApplicationPolicy
   def create?
     user&.treasurer? || (user&.main_bartender? && record.activity.present?)
   end
+
+  def permitted_attributes
+    %i[description amount user_id activity_id]
+  end
 end

--- a/app/policies/invoice_policy.rb
+++ b/app/policies/invoice_policy.rb
@@ -13,7 +13,7 @@ class InvoicePolicy < ApplicationPolicy
 
   def permitted_attributes
     [
-      :user_id, :activity_id, :name_override, :email_override, :rows,
+      :user_id, :activity_id, :name_override, :email_override,
       { rows_attributes: %i[name amount price] }
     ]
   end

--- a/app/policies/invoice_policy.rb
+++ b/app/policies/invoice_policy.rb
@@ -10,4 +10,11 @@ class InvoicePolicy < ApplicationPolicy
   def pay?
     show?
   end
+
+  def permitted_attributes
+    [
+      :user_id, :activity_id, :name_override, :email_override, :rows,
+      { rows_attributes: %i[name amount price] }
+    ]
+  end
 end

--- a/app/policies/order_policy.rb
+++ b/app/policies/order_policy.rb
@@ -16,4 +16,16 @@ class OrderPolicy < ApplicationPolicy
   def create?
     user&.treasurer? || user&.renting_manager? || user&.main_bartender?
   end
+
+  def permitted_attributes
+    %i[user_id paid_with_cash paid_with_pin activity_id]
+  end
+
+  def permitted_attributes_for_create
+    permitted_attributes + [order_rows_attributes: %i[id product_id product_count]]
+  end
+
+  def permitted_attributes_for_update
+    [:id, order_rows_attributes: %i[id product_count]]
+  end
 end

--- a/app/policies/order_policy.rb
+++ b/app/policies/order_policy.rb
@@ -26,6 +26,6 @@ class OrderPolicy < ApplicationPolicy
   end
 
   def permitted_attributes_for_update
-    [:id, { order_rows_attributes: %i[id product_count] }]
+    [{ order_rows_attributes: %i[id product_count] }]
   end
 end

--- a/app/policies/order_policy.rb
+++ b/app/policies/order_policy.rb
@@ -26,6 +26,6 @@ class OrderPolicy < ApplicationPolicy
   end
 
   def permitted_attributes_for_update
-    [:id, order_rows_attributes: %i[id product_count]]
+    [:id, { order_rows_attributes: %i[id product_count] }]
   end
 end

--- a/app/policies/price_list_policy.rb
+++ b/app/policies/price_list_policy.rb
@@ -36,4 +36,8 @@ class PriceListPolicy < ApplicationPolicy
   def search?
     index?
   end
+
+  def permitted_attributes
+    %i[name]
+  end
 end

--- a/app/policies/product_policy.rb
+++ b/app/policies/product_policy.rb
@@ -9,7 +9,7 @@ class ProductPolicy < ApplicationPolicy
 
   def permitted_attributes
     [
-      :name, :category, :color, :requires_age, :id,
+      :name, :category, :color, :requires_age,
       { product_prices_attributes: %i[id product_id price_list_id price _destroy] }
     ]
   end

--- a/app/policies/product_policy.rb
+++ b/app/policies/product_policy.rb
@@ -6,4 +6,11 @@ class ProductPolicy < ApplicationPolicy
   def update?
     create?
   end
+
+  def permitted_attributes
+    [
+      :name, :category, :color, :requires_age, :id,
+      { product_prices_attributes: %i[id product_id price_list_id price _destroy] }
+    ]
+  end
 end

--- a/app/policies/sofia_account_policy.rb
+++ b/app/policies/sofia_account_policy.rb
@@ -18,4 +18,8 @@ class SofiaAccountPolicy < ApplicationPolicy
   def disable_otp?
     update?
   end
+
+  def permitted_attributes
+    %i[username password password_confirmation]
+  end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -22,4 +22,18 @@ class UserPolicy < ApplicationPolicy
   def update_with_sofia_account?
     record == user
   end
+
+  def permitted_attributes
+    %i[name email provider sub_provider]
+  end
+
+  def permitted_attributes_for_update
+    %i[name email deactivated]
+  end
+
+  def permitted_attributes_for_update_with_sofia_account
+    base = %i[email sub_provider]
+    base += %i[name deactivated] if user&.treasurer?
+    base + [{ sofia_account_attributes: %i[id username] }]
+  end
 end


### PR DESCRIPTION
move Permited Atributes to Policy
Fixes https://github.com/csvalpha/sofia/issues/191


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Per-resource attribute whitelists added for create/update, including nested form attributes for invoices, orders, and products.

* Refactor
  * Controllers standardized to use policy-driven parameter helpers, unifying how attributes are permitted across activities, orders, invoices, products, price lists, users, credit mutations, and Sofia accounts.

* Chores
  * Default empty permission hook added to the application policy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->