### PR TITLE
Bugfix: add better limits on payments & credit mutations

### DIFF
--- a/app/models/credit_mutation.rb
+++ b/app/models/credit_mutation.rb
@@ -4,7 +4,7 @@ class CreditMutation < ApplicationRecord
   belongs_to :created_by, class_name: 'User'
 
   validates :description, presence: true
-  validates :amount, presence: true, numericality: { less_than_or_equal_to: 1000 }
+  validates :amount, presence: true, numericality: { less_than_or_equal_to: 5000 }
 
   validate :activity_not_locked
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -79,15 +79,15 @@ class Payment < ApplicationRecord
     return unless user
 
     min_amount = Rails.application.config.x.min_payment_amount
-    max_amount = 1000
-    errors.add(:amount, "must be bigger than or equal to €#{format('%.2f', min_amount)}") unless amount && (amount >= min_amount)
+    max_amount = Rails.application.config.x.max_payment_amount
+    errors.add(:amount, "must be greater than or equal to €#{format('%.2f', min_amount)}") unless amount && (amount >= min_amount)
     errors.add(:amount, "must be less than or equal to €#{format('%.2f', max_amount)}") unless amount && (amount <= max_amount)
   end
 
   def invoice_amount
     return unless invoice
 
-    min_amount = 1
-    errors.add(:amount, "must be bigger than or equal to €#{format('%.2f', min_amount)}") unless amount && (amount >= min_amount)
+    min_amount = Rails.application.config.x.min_invoice_amount
+    errors.add(:amount, "must be greater than or equal to €#{format('%.2f', min_amount)}") unless amount && (amount >= min_amount)
   end
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -75,7 +75,7 @@ class Payment < ApplicationRecord
     errors.add(:payment, 'must belong to a user xor invoice') unless user.present? ^ invoice.present?
   end
 
-  def user_amount
+  def user_amount # rubocop:disable Metrics/AbcSize
     return unless user
 
     min_amount = Rails.application.config.x.min_payment_amount

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -17,6 +17,7 @@ class Payment < ApplicationRecord
 
   validate :user_xor_invoice
   validate :user_amount
+  validate :invoice_amount
 
   scope :not_completed, -> { where.not(status: COMPLETE_STATUSES) }
 
@@ -78,6 +79,15 @@ class Payment < ApplicationRecord
     return unless user
 
     min_amount = Rails.application.config.x.min_payment_amount
+    max_amount = 1000
+    errors.add(:amount, "must be bigger than or equal to €#{format('%.2f', min_amount)}") unless amount && (amount >= min_amount)
+    errors.add(:amount, "must be less than or equal to €#{format('%.2f', max_amount)}") unless amount && (amount <= max_amount)
+  end
+
+  def invoice_amount
+    return unless invoice
+
+    min_amount = 1
     errors.add(:amount, "must be bigger than or equal to €#{format('%.2f', min_amount)}") unless amount && (amount >= min_amount)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -83,6 +83,8 @@ module Sofia
     config.x.deposit_button_enabled = ENV.fetch('DEPOSIT_BUTTON_ENABLED', 'true') == 'true'
 
     config.x.min_payment_amount   = [ENV.fetch('MIN_PAYMENT_AMOUNT', '21.8').to_f, 0.01].max
+    config.x.max_payment_amount   = ENV.fetch('MAX_PAYMENT_AMOUNT', '1000')
+    config.x.min_invoice_amount   = [ENV.fetch('MIN_INVOICE_AMOUNT', '1').to_f, 0.01].max
 
     config.x.codes                = {
       beer: ENV.fetch('CODE_BEER', nil),

--- a/config/application.rb
+++ b/config/application.rb
@@ -83,7 +83,7 @@ module Sofia
     config.x.deposit_button_enabled = ENV.fetch('DEPOSIT_BUTTON_ENABLED', 'true') == 'true'
 
     config.x.min_payment_amount   = [ENV.fetch('MIN_PAYMENT_AMOUNT', '21.8').to_f, 0.01].max
-    config.x.max_payment_amount   = ENV.fetch('MAX_PAYMENT_AMOUNT', '1000')
+    config.x.max_payment_amount   = ENV.fetch('MAX_PAYMENT_AMOUNT', '1000').to_f
     config.x.min_invoice_amount   = [ENV.fetch('MIN_INVOICE_AMOUNT', '1').to_f, 0.01].max
 
     config.x.codes                = {

--- a/spec/models/credit_mutation_spec.rb
+++ b/spec/models/credit_mutation_spec.rb
@@ -31,9 +31,23 @@ RSpec.describe CreditMutation do
     end
 
     context 'when with too high amount' do
-      subject(:mutation) { build_stubbed(:credit_mutation, amount: 1001) }
+      subject(:mutation) { build_stubbed(:credit_mutation, amount: 5001) }
 
       it { expect(mutation).not_to be_valid }
+    end
+
+    context 'when with boundary amounts' do
+      context 'when at maximum amount' do
+        subject(:mutation) { build_stubbed(:credit_mutation, amount: 5000) }
+
+        it { expect(mutation).to be_valid }
+      end
+
+      context 'when just over maximum amount' do
+        subject(:mutation) { build_stubbed(:credit_mutation, amount: 5000.01) }
+
+        it { expect(mutation).not_to be_valid }
+      end
     end
 
     context 'when with a locked activity' do

--- a/spec/models/credit_mutation_spec.rb
+++ b/spec/models/credit_mutation_spec.rb
@@ -30,12 +30,6 @@ RSpec.describe CreditMutation do
       it { expect(mutation).not_to be_valid }
     end
 
-    context 'when with too high amount' do
-      subject(:mutation) { build_stubbed(:credit_mutation, amount: 5001) }
-
-      it { expect(mutation).not_to be_valid }
-    end
-
     context 'when with boundary amounts' do
       context 'when at maximum amount' do
         subject(:mutation) { build_stubbed(:credit_mutation, amount: 5000) }

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -38,6 +38,46 @@ RSpec.describe Payment do
       end
     end
 
+    context 'when with too high amount' do
+      context 'when with user' do
+        subject(:payment) { build_stubbed(:payment, amount: 1001) }
+
+        it { expect(payment).not_to be_valid }
+      end
+
+      context 'when with invoice and high amount' do
+        subject(:payment) { build_stubbed(:payment, :invoice, amount: 1001) }
+
+        it { expect(payment).to be_valid }
+      end
+    end
+
+    context 'when with boundary amounts' do
+      context 'when with user at max amount' do
+        subject(:payment) { build_stubbed(:payment, amount: 1000) }
+
+        it { expect(payment).to be_valid }
+      end
+
+      context 'when with user just over max amount' do
+        subject(:payment) { build_stubbed(:payment, amount: 1000.01) }
+
+        it { expect(payment).not_to be_valid }
+      end
+
+      context 'when with invoice below minimum' do
+        subject(:payment) { build_stubbed(:payment, :invoice, amount: 0.99) }
+
+        it { expect(payment).not_to be_valid }
+      end
+
+      context 'when with invoice at minimum' do
+        subject(:payment) { build_stubbed(:payment, :invoice, amount: 1) }
+
+        it { expect(payment).to be_valid }
+      end
+    end
+
     context 'when without a status' do
       subject(:payment) { build_stubbed(:payment, status: nil) }
 


### PR DESCRIPTION
Somebody tried to uplift their saldo with 100,000 euro and this made the request to Mollie fail.

In the past there have been situations where an invoice for €0 was generated which resulted in the same error, and there are situations when the treasurer needs to make credit mutations bigger than €1,000. 

All these situations will be addressed with this PR by:
- Adding validation to prevent user payments above €1,000 (configurable via `MAX_PAYMENT_AMOUNT`)
- Adding minimum €1 validation for invoice payments (configurable via `MIN_INVOICE_AMOUNT`)
- Increasing the credit mutation limit from €1,000 to €5,000 to allow for larger credit mutations
- Extracting payment limits to application config for easier management
- Adding comprehensive test coverage for all boundary values
- Improving validation error messages for clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where excessively large payment amounts could be submitted, preventing Mollie API failures
  * Added proper validation limits to prevent abuse while allowing legitimate large transactions

* **Improvements**
  * Maximum credit mutation amount increased from €1,000 to €5,000
  * New configurable payment limits (max and min) to control standard vs. invoice-based payment rules
  * User payments now capped at €1,000 (configurable)
  * Invoice payments now enforce a minimum of €1
  * All payment limits now use centralized config values with safety guards
  
* **Tests**
  * Added boundary value test coverage for payment validations
  * Updated credit mutation specs to reflect new €5,000 limit
<!-- end of auto-generated comment: release notes by coderabbit.ai -->