### PR TITLE
Feature: more specific mailing

### DIFF
--- a/app/jobs/credit_insufficient_notification_job.rb
+++ b/app/jobs/credit_insufficient_notification_job.rb
@@ -24,11 +24,9 @@ class CreditInsufficientNotificationJob < ApplicationJob
   end
 
   def send_notification_delivery_reports(success_count, unnotifyable_users)
-    User.treasurer.each do |treasurer|
-      UserCreditMailer.credit_delivery_report_mail(
-        treasurer, success_count, unnotifyable_users
-      ).deliver_later
-    end
+    UserCreditMailer.credit_delivery_report_mail(
+      success_count, unnotifyable_users
+    ).deliver_later
 
     return if Rails.env.local?
 

--- a/app/mailers/user_credit_mailer.rb
+++ b/app/mailers/user_credit_mailer.rb
@@ -9,9 +9,6 @@ class UserCreditMailer < ApplicationMailer
 
   # rubocop:disable Metrics/AbcSize
   def credit_delivery_report_mail(success_count, unnotifyable_users)
-    @user = Struct.new(:name).new(
-      Rails.application.config.x.treasurer_name || Rails.application.config.x.treasurer_title.capitalize
-    )
     @unnotifyable_users = unnotifyable_users
     @success_count = success_count
     @title = 'Notificatie over de saldomail'

--- a/app/mailers/user_credit_mailer.rb
+++ b/app/mailers/user_credit_mailer.rb
@@ -7,6 +7,7 @@ class UserCreditMailer < ApplicationMailer
     mail to: user.email, subject: 'Verzoek met betrekking tot uw Zatladder saldo'
   end
 
+  # rubocop:disable Metrics/AbcSize
   def credit_delivery_report_mail(success_count, unnotifyable_users)
     @user = Struct.new(:name).new(
       Rails.application.config.x.treasurer_name || Rails.application.config.x.treasurer_title.capitalize
@@ -19,6 +20,7 @@ class UserCreditMailer < ApplicationMailer
 
     mail to: Rails.application.config.x.treasurer_email, subject:
   end
+  # rubocop:enable Metrics/AbcSize
 
   def new_credit_mutation_mail(credit_mutation)
     @user = credit_mutation.user

--- a/app/mailers/user_credit_mailer.rb
+++ b/app/mailers/user_credit_mailer.rb
@@ -7,7 +7,6 @@ class UserCreditMailer < ApplicationMailer
     mail to: user.email, subject: 'Verzoek met betrekking tot uw Zatladder saldo'
   end
 
-  # rubocop:disable Metrics/AbcSize
   def credit_delivery_report_mail(success_count, unnotifyable_users)
     @user = Struct.new(:name).new(
       Rails.application.config.x.treasurer_name
@@ -20,7 +19,6 @@ class UserCreditMailer < ApplicationMailer
 
     mail to: Rails.application.config.x.treasurer_email, subject:
   end
-  # rubocop:enable Metrics/AbcSize
 
   def new_credit_mutation_mail(credit_mutation)
     @user = credit_mutation.user

--- a/app/mailers/user_credit_mailer.rb
+++ b/app/mailers/user_credit_mailer.rb
@@ -8,8 +8,8 @@ class UserCreditMailer < ApplicationMailer
   end
 
   def credit_delivery_report_mail(success_count, unnotifyable_users)
-    @user = OpenStruct.new(
-      name: Rails.application.config.x.treasurer_name || Rails.application.config.x.treasurer_title.capitalize
+    @user = Struct.new(:name).new(
+      Rails.application.config.x.treasurer_name || Rails.application.config.x.treasurer_title.capitalize
     )
     @unnotifyable_users = unnotifyable_users
     @success_count = success_count

--- a/app/mailers/user_credit_mailer.rb
+++ b/app/mailers/user_credit_mailer.rb
@@ -7,15 +7,14 @@ class UserCreditMailer < ApplicationMailer
     mail to: user.email, subject: 'Verzoek met betrekking tot uw Zatladder saldo'
   end
 
-  def credit_delivery_report_mail(treasurer, success_count, unnotifyable_users)
-    @user = treasurer
+  def credit_delivery_report_mail(success_count, unnotifyable_users)
     @unnotifyable_users = unnotifyable_users
     @success_count = success_count
     @title = 'Notificatie over de saldomail'
 
     subject = "Er is #{@success_count.positive? ? 'een' : 'geen'} saldomail verstuurd"
 
-    mail to: treasurer.email, subject:
+    mail to: Rails.application.config.x.treasurer_email, subject:
   end
 
   def new_credit_mutation_mail(credit_mutation)

--- a/app/mailers/user_credit_mailer.rb
+++ b/app/mailers/user_credit_mailer.rb
@@ -8,6 +8,9 @@ class UserCreditMailer < ApplicationMailer
   end
 
   def credit_delivery_report_mail(success_count, unnotifyable_users)
+    @user = OpenStruct.new(
+      name: Rails.application.config.x.treasurer_name || Rails.application.config.x.treasurer_title.capitalize
+    )
     @unnotifyable_users = unnotifyable_users
     @success_count = success_count
     @title = 'Notificatie over de saldomail'

--- a/app/mailers/user_credit_mailer.rb
+++ b/app/mailers/user_credit_mailer.rb
@@ -7,7 +7,6 @@ class UserCreditMailer < ApplicationMailer
     mail to: user.email, subject: 'Verzoek met betrekking tot uw Zatladder saldo'
   end
 
-  # rubocop:disable Metrics/AbcSize
   def credit_delivery_report_mail(success_count, unnotifyable_users)
     @unnotifyable_users = unnotifyable_users
     @success_count = success_count
@@ -17,7 +16,6 @@ class UserCreditMailer < ApplicationMailer
 
     mail to: Rails.application.config.x.treasurer_email, subject:
   end
-  # rubocop:enable Metrics/AbcSize
 
   def new_credit_mutation_mail(credit_mutation)
     @user = credit_mutation.user

--- a/app/mailers/user_credit_mailer.rb
+++ b/app/mailers/user_credit_mailer.rb
@@ -7,7 +7,11 @@ class UserCreditMailer < ApplicationMailer
     mail to: user.email, subject: 'Verzoek met betrekking tot uw Zatladder saldo'
   end
 
+  # rubocop:disable Metrics/AbcSize
   def credit_delivery_report_mail(success_count, unnotifyable_users)
+    @user = Struct.new(:name).new(
+      Rails.application.config.x.treasurer_name
+    )
     @unnotifyable_users = unnotifyable_users
     @success_count = success_count
     @title = 'Notificatie over de saldomail'
@@ -16,6 +20,7 @@ class UserCreditMailer < ApplicationMailer
 
     mail to: Rails.application.config.x.treasurer_email, subject:
   end
+  # rubocop:enable Metrics/AbcSize
 
   def new_credit_mutation_mail(credit_mutation)
     @user = credit_mutation.user

--- a/spec/jobs/credit_insufficient_notification_job_spec.rb
+++ b/spec/jobs/credit_insufficient_notification_job_spec.rb
@@ -10,11 +10,6 @@ RSpec.describe CreditInsufficientNotificationJob do
     let(:user_without_email) do
       create(:user, name: 'Good Emailless', email: nil, provider: 'some_external_source')
     end
-    let(:treasurer) do
-      create(:user,
-             name: 'Sis Treasures', email: 'treasurer@csvalpha.nl',
-             roles: [create(:role, role_type: :treasurer)])
-    end
     let(:emails) { ActionMailer::Base.deliveries }
 
     subject(:job) { perform_enqueued_jobs { described_class.perform_now } }
@@ -25,14 +20,13 @@ RSpec.describe CreditInsufficientNotificationJob do
       create(:credit_mutation, user: negative_user, amount: -2)
       create(:credit_mutation, user: negative_user_without_email, amount: -2)
       user_without_email
-      treasurer
       job
     end
 
     it { expect(emails.size).to eq 2 }
     it { expect(emails.first.to.first).to eq negative_user.email }
     it { expect(emails.first.body.to_s).to include 'http://testhost:1337/payments/add' }
-    it { expect(emails.second.to.first).to eq treasurer.email }
+    it { expect(emails.second.to.first).to eq Rails.application.config.x.treasurer_email }
     it { expect(emails.second.body.to_s).to include negative_user_without_email.name }
     it { expect(emails.second.body.to_s).not_to include user_without_email.name }
   end

--- a/spec/mailers/previews/user_credit_mailer_preview.rb
+++ b/spec/mailers/previews/user_credit_mailer_preview.rb
@@ -6,11 +6,10 @@ class UserCreditMailerPreview < ActionMailer::Preview
   end
 
   def credit_delivery_report_mail
-    treasurer = FactoryBot.create(:user, :treasurer)
     unnotifyable_users = FactoryBot.create_list(:user, 2).map(&:name)
     success_count = 2
 
-    UserCreditMailer.credit_delivery_report_mail(treasurer, success_count, unnotifyable_users)
+    UserCreditMailer.credit_delivery_report_mail(success_count, unnotifyable_users)
   end
 
   def new_credit_mutation_mail


### PR DESCRIPTION
**Summary**
Refactors credit delivery report emails to send to a single configured email address (TREASURER_EMAIL) instead of every user with the treasurer role.

**Motivation**
Previously, all users with the treasurer role received credit notification emails. This caused:

Administrative accounts to receive unnecessary emails

Which annoyed me a lot, so it needed to change :)

**Changes**

- Modified CreditInsufficientNotificationJob to send one email to [Rails.application.config.x.treasurer_email]
- Updated UserCreditMailer#credit_delivery_report_mail to use the configured email directly
- Updated associated tests and mailer previews

This fixes https://github.com/csvalpha/sofia/issues/442 (kinda)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Credit delivery reports are consolidated into a single report sent to the central treasurer contact configured in the app, replacing individual per‑treasurer emails. User-facing insufficient-credit emails continue to be sent as before.

* **Tests**
  * Tests updated to expect the consolidated report delivery to the configured treasurer contact.

* **Documentation / Previews**
  * Mailer previews updated to reflect the consolidated report signature and recipient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->